### PR TITLE
Change parser dependencies.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@
 module.exports = {
   parserOptions: {
     sourceType: "script",
-    ecmaVersion: 2020,
+    ecmaVersion: "latest",
     project: require.resolve("./tsconfig.json"),
   },
   extends: [

--- a/README.md
+++ b/README.md
@@ -46,7 +46,13 @@ See [documents](https://ota-meshi.github.io/eslint-plugin-astro/).
 ## :cd: Installation
 
 ```bash
-npm install --save-dev eslint eslint-plugin-astro astro-eslint-parser @typescript-eslint/parser
+npm install --save-dev eslint eslint-plugin-astro
+```
+
+If you write TypeScript in Astro components, install the `@typescript-eslint/parser` as well:
+
+```bash
+npm install --save-dev @typescript-eslint/parser
 ```
 
 > **Requirements**
@@ -84,6 +90,7 @@ module.exports = {
       // Allows Astro components to be parsed.
       parser: "astro-eslint-parser",
       // Parse the script in `.astro` as TypeScript by adding the following configuration.
+      // It's the setting you need when using TypeScript.
       parserOptions: {
         parser: "@typescript-eslint/parser",
         extraFileExtensions: [".astro"],
@@ -118,6 +125,7 @@ module.exports = {
       // Allows Astro components to be parsed.
       parser: "astro-eslint-parser",
       // Parse the script in `.astro` as TypeScript by adding the following configuration.
+      // It's the setting you need when using TypeScript.
       parserOptions: {
         parser: "@typescript-eslint/parser",
         extraFileExtensions: [".astro"],

--- a/docs-build/shim/module.mjs
+++ b/docs-build/shim/module.mjs
@@ -1,3 +1,8 @@
 export default {
-  createRequire: () => () => null,
+  createRequire,
+}
+export function createRequire() {
+  return () => {
+    throw new Error()
+  }
 }

--- a/docs-build/src/components/ESLintCodeBlock.svelte
+++ b/docs-build/src/components/ESLintCodeBlock.svelte
@@ -56,7 +56,7 @@
     config={{
       parser: "astro-auto-eslint-parser",
       parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: "latest",
         sourceType: "module",
         parser: "@typescript-eslint/parser",
       },

--- a/docs-build/src/components/ESLintPlayground.svelte
+++ b/docs-build/src/components/ESLintPlayground.svelte
@@ -138,7 +138,7 @@ let b: number = 1;
         config={{
           parser: "astro-auto-eslint-parser",
           parserOptions: {
-            ecmaVersion: 2020,
+            ecmaVersion: "latest",
             sourceType: "module",
             parser: "@typescript-eslint/parser",
           },

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -5,7 +5,13 @@
 ## :cd: Installation
 
 ```bash
-npm install --save-dev eslint eslint-plugin-astro astro-eslint-parser @typescript-eslint/parser
+npm install --save-dev eslint eslint-plugin-astro
+```
+
+If you write TypeScript in Astro components, install the `@typescript-eslint/parser` as well:
+
+```bash
+npm install --save-dev @typescript-eslint/parser
 ```
 
 > **Requirements**
@@ -40,6 +46,7 @@ module.exports = {
       // Allows Astro components to be parsed.
       parser: "astro-eslint-parser",
       // Parse the script in `.astro` as TypeScript by adding the following configuration.
+      // It's the setting you need when using TypeScript.
       parserOptions: {
         parser: "@typescript-eslint/parser",
         extraFileExtensions: [".astro"],
@@ -74,6 +81,7 @@ module.exports = {
       // Allows Astro components to be parsed.
       parser: "astro-eslint-parser",
       // Parse the script in `.astro` as TypeScript by adding the following configuration.
+      // It's the setting you need when using TypeScript.
       parserOptions: {
         parser: "@typescript-eslint/parser",
         extraFileExtensions: [".astro"],

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
   },
   "homepage": "https://ota-meshi.github.io/eslint-plugin-astro/",
   "dependencies": {
+    "astro-eslint-parser": "^0.2.1",
     "eslint-utils": "^3.0.0",
     "@typescript-eslint/types": "^5.25.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "^5.25.0",
-    "astro-eslint-parser": "^0.2.0"
+    "eslint": ">=7.0.0"
   },
   "devDependencies": {
     "@astrojs/svelte": "^0.1.3",
@@ -64,7 +64,6 @@
     "@typescript-eslint/parser": "^5.25.0",
     "assert": "^2.0.0",
     "astro": "^1.0.0-beta.35",
-    "astro-eslint-parser": "^0.2.1",
     "env-cmd": "^10.1.0",
     "esbuild": "^0.14.41",
     "eslint": "^8.15.0",

--- a/src/shared/client-script/parse-expression.ts
+++ b/src/shared/client-script/parse-expression.ts
@@ -1,12 +1,12 @@
-import { parseForESLint } from "@typescript-eslint/parser"
 import { traverseNodes } from "astro-eslint-parser"
 import type { TSESTree } from "@typescript-eslint/types"
+import { resolveParser } from "../../utils/resolve-parser"
 
 /**
  * Parse expression
  */
 export function parseExpression(code: string): TSESTree.Expression {
-  const result = parseForESLint(
+  const result = resolveParser().parseForESLint(
     `(
 ${code}
 )`,

--- a/src/utils/resolve-parser/espree.ts
+++ b/src/utils/resolve-parser/espree.ts
@@ -1,0 +1,42 @@
+import type { ParserOptions, TSESTree } from "@typescript-eslint/types"
+import { createRequire } from "module"
+import path from "path"
+
+type Espree = {
+  parse(code: string, options?: ParserOptions | null): TSESTree.Program
+}
+let espreeCache: Espree | null = null
+
+/** Checks if given path is linter path */
+function isLinterPath(p: string): boolean {
+  return (
+    // ESLint 6 and above
+    p.includes(`eslint${path.sep}lib${path.sep}linter${path.sep}linter.js`) ||
+    // ESLint 5
+    p.includes(`eslint${path.sep}lib${path.sep}linter.js`)
+  )
+}
+
+/**
+ * Load `espree` from the loaded ESLint.
+ * If the loaded ESLint was not found, just returns `require("espree")`.
+ */
+export function getEspree(): Espree {
+  if (!espreeCache) {
+    // Lookup the loaded eslint
+    const linterPath = Object.keys(require.cache || {}).find(isLinterPath)
+    if (linterPath) {
+      try {
+        espreeCache = createRequire(linterPath)("espree")
+      } catch {
+        // ignore
+      }
+    }
+    if (!espreeCache) {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- ignore
+      espreeCache = require("espree")
+    }
+  }
+
+  return espreeCache!
+}

--- a/src/utils/resolve-parser/espree.ts
+++ b/src/utils/resolve-parser/espree.ts
@@ -1,6 +1,7 @@
 import type { ParserOptions, TSESTree } from "@typescript-eslint/types"
 import { createRequire } from "module"
 import path from "path"
+import { requireUserLocal } from "./require-user"
 
 type Espree = {
   parse(code: string, options?: ParserOptions | null): TSESTree.Program
@@ -9,12 +10,7 @@ let espreeCache: Espree | null = null
 
 /** Checks if given path is linter path */
 function isLinterPath(p: string): boolean {
-  return (
-    // ESLint 6 and above
-    p.includes(`eslint${path.sep}lib${path.sep}linter${path.sep}linter.js`) ||
-    // ESLint 5
-    p.includes(`eslint${path.sep}lib${path.sep}linter.js`)
-  )
+  return p.includes(`eslint${path.sep}lib${path.sep}linter${path.sep}linter.js`)
 }
 
 /**
@@ -32,10 +28,13 @@ export function getEspree(): Espree {
         // ignore
       }
     }
-    if (!espreeCache) {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports -- ignore
-      espreeCache = require("espree")
-    }
+  }
+  if (!espreeCache) {
+    espreeCache = requireUserLocal("espree")
+  }
+  if (!espreeCache) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- ignore
+    espreeCache = require("espree")
   }
 
   return espreeCache!

--- a/src/utils/resolve-parser/index.ts
+++ b/src/utils/resolve-parser/index.ts
@@ -1,0 +1,81 @@
+import { createRequire } from "module"
+import path from "path"
+import type { parseForESLint } from "@typescript-eslint/parser"
+import { getEspree } from "./espree"
+
+/** Resolve parser */
+export function resolveParser(): { parseForESLint: typeof parseForESLint } {
+  const modules = [
+    "@typescript-eslint/parser",
+    "@babel/eslint-parser",
+    "espree",
+  ]
+  for (const id of modules) {
+    const parser = toParserForESLint(requireLocal(id))
+    if (!parser) {
+      continue
+    }
+    return parser
+  }
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires -- ignore
+    return toParserForESLint(require("@typescript-eslint/parser"))!
+  } catch {
+    // ignore
+  }
+  return toParserForESLint(getEspree())!
+}
+
+/** To the parser for ESLint */
+function toParserForESLint(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ignore
+  mod: any,
+): { parseForESLint: typeof parseForESLint } | null {
+  for (const m of [mod, mod && mod.default]) {
+    if (!m) {
+      continue
+    }
+    if (typeof m.parseForESLint === "function") {
+      return m
+    }
+    if (typeof m.parse === "function") {
+      return {
+        parseForESLint(...args) {
+          return {
+            ast: m.parse(...args),
+          } as never
+        },
+      }
+    }
+  }
+  return null
+}
+
+/** Get the installed parser ID */
+export function getInstalledParserId():
+  | "@typescript-eslint/parser"
+  | "@babel/eslint-parser"
+  | undefined {
+  const modules = ["@typescript-eslint/parser", "@babel/eslint-parser"] as const
+  for (const id of modules) {
+    const mod = requireLocal(id)
+    if (!mod) {
+      continue
+    }
+    return id
+  }
+  return undefined
+}
+
+/** Require from use local */
+function requireLocal(id: string) {
+  try {
+    // Apply a patch to parse .astro files as TSX.
+    const cwd = process.cwd()
+    const relativeTo = path.join(cwd, "__placeholder__.js")
+    return createRequire(relativeTo)(id)
+  } catch {
+    return null
+  }
+}

--- a/src/utils/resolve-parser/index.ts
+++ b/src/utils/resolve-parser/index.ts
@@ -26,6 +26,15 @@ export function resolveParser(): { parseForESLint: typeof parseForESLint } {
   return toParserForESLint(getEspree())!
 }
 
+/** Get the installed parser ID */
+export function getInstalledParserId():
+  | "@typescript-eslint/parser"
+  | "@babel/eslint-parser"
+  | undefined {
+  const modules = ["@typescript-eslint/parser", "@babel/eslint-parser"] as const
+  return modules.find(requireUserLocal)
+}
+
 /** To the parser for ESLint */
 function toParserForESLint(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ignore
@@ -49,20 +58,4 @@ function toParserForESLint(
     }
   }
   return null
-}
-
-/** Get the installed parser ID */
-export function getInstalledParserId():
-  | "@typescript-eslint/parser"
-  | "@babel/eslint-parser"
-  | undefined {
-  const modules = ["@typescript-eslint/parser", "@babel/eslint-parser"] as const
-  for (const id of modules) {
-    const mod = requireUserLocal(id)
-    if (!mod) {
-      continue
-    }
-    return id
-  }
-  return undefined
 }

--- a/src/utils/resolve-parser/index.ts
+++ b/src/utils/resolve-parser/index.ts
@@ -1,7 +1,6 @@
-import { createRequire } from "module"
-import path from "path"
 import type { parseForESLint } from "@typescript-eslint/parser"
 import { getEspree } from "./espree"
+import { requireUserLocal } from "./require-user"
 
 /** Resolve parser */
 export function resolveParser(): { parseForESLint: typeof parseForESLint } {
@@ -11,7 +10,7 @@ export function resolveParser(): { parseForESLint: typeof parseForESLint } {
     "espree",
   ]
   for (const id of modules) {
-    const parser = toParserForESLint(requireLocal(id))
+    const parser = toParserForESLint(requireUserLocal(id))
     if (!parser) {
       continue
     }
@@ -59,23 +58,11 @@ export function getInstalledParserId():
   | undefined {
   const modules = ["@typescript-eslint/parser", "@babel/eslint-parser"] as const
   for (const id of modules) {
-    const mod = requireLocal(id)
+    const mod = requireUserLocal(id)
     if (!mod) {
       continue
     }
     return id
   }
   return undefined
-}
-
-/** Require from use local */
-function requireLocal(id: string) {
-  try {
-    // Apply a patch to parse .astro files as TSX.
-    const cwd = process.cwd()
-    const relativeTo = path.join(cwd, "__placeholder__.js")
-    return createRequire(relativeTo)(id)
-  } catch {
-    return null
-  }
 }

--- a/src/utils/resolve-parser/require-user.ts
+++ b/src/utils/resolve-parser/require-user.ts
@@ -1,0 +1,13 @@
+import { createRequire } from "module"
+import path from "path"
+
+/** Require from user local */
+export function requireUserLocal<T>(id: string): T | null {
+  try {
+    const cwd = process.cwd()
+    const relativeTo = path.join(cwd, "__placeholder__.js")
+    return createRequire(relativeTo)(id)
+  } catch {
+    return null
+  }
+}

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -174,7 +174,7 @@ function writeFixtures(
       },
       parser: "astro-eslint-parser",
       parserOptions: {
-        ecmaVersion: 2020,
+        ecmaVersion: "latest",
         sourceType: "module",
         parser: "@typescript-eslint/parser",
       },

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -176,10 +176,7 @@ function writeFixtures(
       parserOptions: {
         ecmaVersion: 2020,
         sourceType: "module",
-        parser: {
-          ts: "@typescript-eslint/parser",
-          js: "espree",
-        },
+        parser: "@typescript-eslint/parser",
       },
     },
     config.filename,


### PR DESCRIPTION
Close #26

- Move `astro-eslint-parser` to `dependencies` from `peerDependencies`.
- Remove `@typescript-eslint/parser` from `peerDependencies`.