### PR TITLE
fix: false positives for `for` attr in `astro/jsx-a11y/label-has-associated-control` rule

### DIFF
--- a/.changeset/many-dodos-grin.md
+++ b/.changeset/many-dodos-grin.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-astro": patch
+---
+
+fix: false positives for `for` attr in `astro/jsx-a11y/label-has-associated-control` rule

--- a/src/a11y/rules.ts
+++ b/src/a11y/rules.ts
@@ -16,6 +16,7 @@ const ATTRIBUTE_MAP: Record<string, string | undefined> = {
   "set:html": "dangerouslySetInnerHTML",
   "set:text": "children",
   autofocus: "autoFocus",
+  for: "htmlFor",
 }
 
 /** Get `eslint-plugin-jsx-a11y` rule. */

--- a/tests/fixtures/rules/jsx-a11y/label-has-associated-control/invalid/test01-errors.json
+++ b/tests/fixtures/rules/jsx-a11y/label-has-associated-control/invalid/test01-errors.json
@@ -1,0 +1,7 @@
+[
+  {
+    "message": "A form label must be associated with a control.",
+    "line": 5,
+    "column": 1
+  }
+]

--- a/tests/fixtures/rules/jsx-a11y/label-has-associated-control/invalid/test01-input.astro
+++ b/tests/fixtures/rules/jsx-a11y/label-has-associated-control/invalid/test01-input.astro
@@ -1,0 +1,6 @@
+---
+const domId = "foo"
+---
+
+<label>Surname</label>
+<input type="text" id={domId} />

--- a/tests/fixtures/rules/jsx-a11y/label-has-associated-control/valid/issue123-input.astro
+++ b/tests/fixtures/rules/jsx-a11y/label-has-associated-control/valid/issue123-input.astro
@@ -1,5 +1,4 @@
 ---
-const domId = "foo"
 ---
 
 <form>

--- a/tests/fixtures/rules/jsx-a11y/label-has-associated-control/valid/issue123-input.astro
+++ b/tests/fixtures/rules/jsx-a11y/label-has-associated-control/valid/issue123-input.astro
@@ -1,0 +1,10 @@
+---
+const domId = "foo"
+---
+
+<form>
+  <label class="label" for="address">Address</label>
+  <textarea placeholder="Address" required name="address" id="address"
+  ></textarea>
+  <input type="submit" value="Submit" />
+</form>

--- a/tests/fixtures/rules/jsx-a11y/label-has-associated-control/valid/test01-input.astro
+++ b/tests/fixtures/rules/jsx-a11y/label-has-associated-control/valid/test01-input.astro
@@ -1,0 +1,10 @@
+---
+const domId = "foo"
+---
+
+<label>
+  Surname
+  <input type="text" />
+</label>
+<label for={domId}>Surname</label>
+<input type="text" id={domId} />

--- a/tests/src/rules/jsx-a11y/label-has-associated-control.ts
+++ b/tests/src/rules/jsx-a11y/label-has-associated-control.ts
@@ -1,0 +1,20 @@
+import { RuleTester } from "eslint"
+import { rules } from "../../../../src/utils/rules"
+import { loadTestCases } from "../../../utils/utils"
+
+const rule = rules.find(
+  (r) => r.meta.docs.ruleName === "jsx-a11y/label-has-associated-control",
+)!
+
+const tester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
+})
+
+tester.run(
+  "jsx-a11y/label-has-associated-control",
+  rule as any,
+  loadTestCases("jsx-a11y/label-has-associated-control"),
+)


### PR DESCRIPTION
fixes #123