### PR TITLE
fix: prevent parsing of json script tags

### DIFF
--- a/.changeset/tall-waves-hug.md
+++ b/.changeset/tall-waves-hug.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-astro": patch
+---
+
+fix: prevent parsing of json script tags

--- a/src/processor/index.ts
+++ b/src/processor/index.ts
@@ -20,7 +20,8 @@ export const processor: Linter.Processor = {
         if (
           node.type === "element" &&
           node.name === "script" &&
-          node.children.length
+          node.children.length &&
+          !node.attributes.some(({ name, value }) => name === 'type' && /(json$|importmap)/i.test(value))
         ) {
           shared.addClientScript(code, node, parsed)
         }

--- a/src/processor/index.ts
+++ b/src/processor/index.ts
@@ -21,7 +21,10 @@ export const processor: Linter.Processor = {
           node.type === "element" &&
           node.name === "script" &&
           node.children.length &&
-          !node.attributes.some(({ name, value }) => name === 'type' && /(json$|importmap)/i.test(value))
+          !node.attributes.some(
+            ({ name, value }) =>
+              name === "type" && /json$|importmap/i.test(value),
+          )
         ) {
           shared.addClientScript(code, node, parsed)
         }


### PR DESCRIPTION
Check if a script tag has type ending with json or equals importmap

resolves: #210