### PR TITLE
Add `astro/no-deprecated-getentrybyslug` rule

### DIFF
--- a/.changeset/heavy-carpets-move.md
+++ b/.changeset/heavy-carpets-move.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-astro": minor
+---
+
+feat: add `astro/no-deprecated-getentrybyslug` rule

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ These rules relate to possible syntax or logic errors in Astro component code:
 | [astro/no-deprecated-astro-canonicalurl](https://ota-meshi.github.io/eslint-plugin-astro/rules/no-deprecated-astro-canonicalurl/) | disallow using deprecated `Astro.canonicalURL` | :star: |
 | [astro/no-deprecated-astro-fetchcontent](https://ota-meshi.github.io/eslint-plugin-astro/rules/no-deprecated-astro-fetchcontent/) | disallow using deprecated `Astro.fetchContent()` | :star::wrench: |
 | [astro/no-deprecated-astro-resolve](https://ota-meshi.github.io/eslint-plugin-astro/rules/no-deprecated-astro-resolve/) | disallow using deprecated `Astro.resolve()` | :star: |
+| [astro/no-deprecated-getentrybyslug](https://ota-meshi.github.io/eslint-plugin-astro/rules/no-deprecated-getentrybyslug/) | disallow using deprecated `getEntryBySlug()` | :star: |
 | [astro/no-unused-define-vars-in-style](https://ota-meshi.github.io/eslint-plugin-astro/rules/no-unused-define-vars-in-style/) | disallow unused `define:vars={...}` in `style` tag | :star: |
 | [astro/valid-compile](https://ota-meshi.github.io/eslint-plugin-astro/rules/valid-compile/) | disallow warnings when compiling. | :star: |
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -17,6 +17,7 @@ These rules relate to possible syntax or logic errors in Astro component code:
 | [astro/no-deprecated-astro-canonicalurl](./rules/no-deprecated-astro-canonicalurl.md) | disallow using deprecated `Astro.canonicalURL` | :star: |
 | [astro/no-deprecated-astro-fetchcontent](./rules/no-deprecated-astro-fetchcontent.md) | disallow using deprecated `Astro.fetchContent()` | :star::wrench: |
 | [astro/no-deprecated-astro-resolve](./rules/no-deprecated-astro-resolve.md) | disallow using deprecated `Astro.resolve()` | :star: |
+| [astro/no-deprecated-getentrybyslug](./rules/no-deprecated-getentrybyslug.md) | disallow using deprecated `getEntryBySlug()` | :star: |
 | [astro/no-unused-define-vars-in-style](./rules/no-unused-define-vars-in-style.md) | disallow unused `define:vars={...}` in `style` tag | :star: |
 | [astro/valid-compile](./rules/valid-compile.md) | disallow warnings when compiling. | :star: |
 

--- a/docs/rules/no-deprecated-getentrybyslug.md
+++ b/docs/rules/no-deprecated-getentrybyslug.md
@@ -7,6 +7,7 @@ description: "disallow using deprecated `getEntryBySlug()`"
 
 > disallow using deprecated `getEntryBySlug()`
 
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> **_This rule has not been released yet._** </badge>
 - :gear: This rule is included in `"plugin:astro/recommended"`.
 
 ## :book: Rule Details
@@ -44,4 +45,3 @@ Nothing.
 - [Rule source](https://github.com/ota-meshi/eslint-plugin-astro/blob/main/src/rules/no-deprecated-getentrybyslug.ts)
 - [Test source](https://github.com/ota-meshi/eslint-plugin-astro/blob/main/tests/src/rules/no-deprecated-getentrybyslug.ts)
 - [Test fixture sources](https://github.com/ota-meshi/eslint-plugin-astro/tree/main/tests/fixtures/rules/no-deprecated-getentrybyslug)
-

--- a/docs/rules/no-deprecated-getentrybyslug.md
+++ b/docs/rules/no-deprecated-getentrybyslug.md
@@ -1,0 +1,47 @@
+---
+title: "astro/no-deprecated-getentrybyslug"
+description: "disallow using deprecated `getEntryBySlug()`"
+---
+
+# astro/no-deprecated-getentrybyslug
+
+> disallow using deprecated `getEntryBySlug()`
+
+- :gear: This rule is included in `"plugin:astro/recommended"`.
+
+## :book: Rule Details
+
+This rule reports use of deprecated `getEntryBySlug()`.
+
+<ESLintCodeBlock>
+
+<!--eslint-skip-->
+
+```astro
+---
+/* eslint astro/no-deprecated-getentrybyslug: "error" */
+
+/* ✓ GOOD */
+import { getEntry } from "astro:content";
+
+/* ✗ BAD */
+import { getEntryBySlug } from "astro:content";
+---
+```
+
+</ESLintCodeBlock>
+
+## :wrench: Options
+
+Nothing.
+
+## :books: Further Reading
+
+- [Astro Documentation | API Reference - getEntryBySlug()](https://docs.astro.build/en/reference/api-reference/#getentrybyslug)
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-astro/blob/main/src/rules/no-deprecated-getentrybyslug.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-astro/blob/main/tests/src/rules/no-deprecated-getentrybyslug.ts)
+- [Test fixture sources](https://github.com/ota-meshi/eslint-plugin-astro/tree/main/tests/fixtures/rules/no-deprecated-getentrybyslug)
+

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -13,6 +13,7 @@ export = {
     "astro/no-deprecated-astro-canonicalurl": "error",
     "astro/no-deprecated-astro-fetchcontent": "error",
     "astro/no-deprecated-astro-resolve": "error",
+    "astro/no-deprecated-getentrybyslug": "error",
     "astro/no-unused-define-vars-in-style": "error",
     "astro/valid-compile": "error",
   },

--- a/src/rules/no-deprecated-getentrybyslug.ts
+++ b/src/rules/no-deprecated-getentrybyslug.ts
@@ -1,0 +1,37 @@
+import { createRule } from "../utils"
+import type { TSESTree } from "@typescript-eslint/types"
+
+export default createRule("no-deprecated-getentrybyslug", {
+  meta: {
+    docs: {
+      description: "disallow using deprecated `getEntryBySlug()`",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      deprecated: "'getEntryBySlug()' is deprecated. Use 'getEntry()' instead.",
+    },
+    type: "problem",
+  },
+  create(context) {
+    if (!context.parserServices.isAstro) {
+      return {}
+    }
+
+    return {
+      ImportSpecifier(node: TSESTree.ImportSpecifier) {
+        if (
+          node.imported.name === "getEntryBySlug" &&
+          node.parent?.type === "ImportDeclaration" &&
+          node.parent.source.value === "astro:content"
+        ) {
+          context.report({
+            node,
+            messageId: "deprecated",
+          })
+        }
+      },
+    }
+  },
+})

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -6,6 +6,7 @@ import noConflictSetDirectives from "../rules/no-conflict-set-directives"
 import noDeprecatedAstroCanonicalurl from "../rules/no-deprecated-astro-canonicalurl"
 import noDeprecatedAstroFetchcontent from "../rules/no-deprecated-astro-fetchcontent"
 import noDeprecatedAstroResolve from "../rules/no-deprecated-astro-resolve"
+import noDeprecatedGetentrybyslug from "../rules/no-deprecated-getentrybyslug"
 import noSetHtmlDirective from "../rules/no-set-html-directive"
 import noSetTextDirective from "../rules/no-set-text-directive"
 import noUnusedCssSelector from "../rules/no-unused-css-selector"
@@ -22,6 +23,7 @@ export const rules = [
   noDeprecatedAstroCanonicalurl,
   noDeprecatedAstroFetchcontent,
   noDeprecatedAstroResolve,
+  noDeprecatedGetentrybyslug,
   noSetHtmlDirective,
   noSetTextDirective,
   noUnusedCssSelector,

--- a/tests/fixtures/rules/no-deprecated-getentrybyslug/invalid/test01-errors.json
+++ b/tests/fixtures/rules/no-deprecated-getentrybyslug/invalid/test01-errors.json
@@ -1,0 +1,7 @@
+[
+  {
+    "message": "'getEntryBySlug()' is deprecated. Use 'getEntry()' instead.",
+    "line": 3,
+    "column": 10
+  }
+]

--- a/tests/fixtures/rules/no-deprecated-getentrybyslug/invalid/test01-input.astro
+++ b/tests/fixtures/rules/no-deprecated-getentrybyslug/invalid/test01-input.astro
@@ -1,0 +1,4 @@
+---
+/* ✗ BAD */
+import { getEntryBySlug } from "astro:content"
+---

--- a/tests/fixtures/rules/no-deprecated-getentrybyslug/valid/test01-input.astro
+++ b/tests/fixtures/rules/no-deprecated-getentrybyslug/valid/test01-input.astro
@@ -1,0 +1,4 @@
+---
+/* ✓ GOOD */
+import { getEntry } from "astro:content"
+---

--- a/tests/src/rules/no-deprecated-getentrybyslug.ts
+++ b/tests/src/rules/no-deprecated-getentrybyslug.ts
@@ -1,0 +1,16 @@
+import { RuleTester } from "eslint"
+import rule from "../../../src/rules/no-deprecated-getentrybyslug"
+import { loadTestCases } from "../../utils/utils"
+
+const tester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
+})
+
+tester.run(
+  "no-deprecated-getentrybyslug",
+  rule as any,
+  loadTestCases("no-deprecated-getentrybyslug"),
+)


### PR DESCRIPTION
In the latest Astro, the function `getEntryBySlug` has been [deprecated](https://docs.astro.build/en/reference/api-reference/#getentrybyslug). However, I noticed that there wasn't any rule regarding this function, so I added one.

I ran `npm run new` to add a new rule, followed by `npm run update`. Apologies if I've misunderstood or misfollowed any procedure!