### PR TITLE
test: add broken test of using no-unused-css-selector rule with compo…

### DIFF
--- a/tests/fixtures/rules/no-unused-css-selector/valid/classlist03-input.astro
+++ b/tests/fixtures/rules/no-unused-css-selector/valid/classlist03-input.astro
@@ -1,0 +1,30 @@
+---
+let { tag = 'p' } = Astro.props
+
+let Tag = tag
+
+const baz = false
+---
+
+<Tag class:list={[
+  "foo",
+  {
+    "bar": baz,
+    "quz": !baz,
+  }
+]}></Tag>
+
+<style>
+  .foo {
+    height: 10px;
+    width: 10px;
+  }
+
+  .bar {
+    color: red;
+  }
+
+  .quz {
+    color: blue;
+  }
+</style>


### PR DESCRIPTION
This test is broken.

I just want to show the problem with usage `no-unused-css-selector` rule.

The problem can be solved by deleting these lines of code:
https://github.com/ota-meshi/eslint-plugin-astro/blob/main/src/rules/no-unused-css-selector.ts#L478-L480