### PR TITLE
add docs hint for unsafe return of any resolves #168

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ This can be resolved by overriding the astroHTML.JSX.Element definition with a `
 import "astro/astro-jsx";
 
 declare global {
-  namespace aJSX {
+  namespace JSX {
     // type Element = astroHTML.JSX.Element // We want to use this, but it is defined as any.
     type Element = HTMLElement;
   }

--- a/README.md
+++ b/README.md
@@ -238,6 +238,60 @@ See [the rule list](https://ota-meshi.github.io/eslint-plugin-astro/rules/) to g
 
 See [https://github.com/ota-meshi/astro-eslint-parser#readme](https://github.com/ota-meshi/astro-eslint-parser#readme).
 
+
+### Resolving Error in JSX: Unsafe return of an `any` typed value
+
+Astro supports JSX from multiple frameworks such as **React**, **Preact**, and **Solid.js** by defining JSX Elements as `HTMLElement | any;`. When a framework with a JSX type definition is not present in your project this **any** can cause the ESLint error `@typescript-eslint/no-unsafe-return`.
+
+This can be resolved by overriding the astroHTML.JSX.Element definition with a `*.d.ts` file such as `jsx.d.ts` in your project root directory:
+
+
+```typescript
+import "astro/astro-jsx";
+
+declare global {
+  namespace aJSX {
+    // type Element = astroHTML.JSX.Element // We want to use this, but it is defined as any.
+    type Element = HTMLElement;
+  }
+}
+```
+
+Add this `*.d.ts` to your `tsconfig.eslint.json`:
+
+```json
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    // ...
+    "jsx.d.ts"
+  ]
+}
+
+```
+
+Ensure that any necessary parserOptions in your `.eslintrc.**` have a project key also pointing to this config:
+
+```json
+{
+  // ...
+  "overrides": [
+    {
+      "files": ["*.astro"],
+      "parser": "astro-eslint-parser",
+      "parserOptions": {
+        "parser": "@typescript-eslint/parser",
+        "extraFileExtensions": [".astro"],
+        // add this line
+        "project": "./tsconfig.eslint.json"
+      },
+      // ...
+    }
+    // ...
+  ]}
+
+```
+
 ### Running ESLint from the command line
 
 If you want to run `eslint` from the command line, make sure you include the `.astro` extension using [the `--ext` option](https://eslint.org/docs/user-guide/configuring#specifying-file-extensions-to-lint) or a glob pattern, because ESLint targets only `.js` files by default.


### PR DESCRIPTION

As [@saibotk](https://github.com/ota-meshi/eslint-plugin-astro/issues/168#issuecomment-1957546400) suggested, this pull request adds instructions on how to resolve `no unsafe return` JSX Errors. 

Since the issue is caused by Astro's JSX type support for multiple JSX implementations, it probably won't be fixed upstream...

[Here's a fresh example repo with the suggested configs](https://github.com/david-abell/astro-jsx). I started with a fresh npx astro create just to be sure.

@ota-meshi your original suggested [fix](https://github.com/ota-meshi/eslint-plugin-astro/issues/168#issuecomment-1439480332) also included overriding `type IntrinsicElements = astroHTML.JSX.IntrinsicElements` but this does not seem to affect the simple test cases I created so I don't know if I'm just testing the wrong thing or if its not necessary. I can add it back in to the example if it is indeed necessary.

Hope this helps. I know its something I'll probably need to refer to in the future.