### PR TITLE
feat: compatibility flat configs type

### DIFF
--- a/.changeset/brave-crabs-lick.md
+++ b/.changeset/brave-crabs-lick.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-astro": minor
+---
+
+feat: compatibility flat configs type

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build:meta": "npm run ts -- ./tools/update-meta.ts",
     "build:ts": "tsc --project ./tsconfig.build.json",
     "clean": "rimraf lib .nyc_output dist coverage",
-    "test": "npm run mocha -- \"tests/src/**/*.ts\" --reporter dot --timeout 60000",
+    "test": "npm run mocha -- \"tests/src/**/*.ts\" --reporter dot --timeout 60000 && npm run test:type",
+    "test:type": "tsc",
     "cover": "nyc --reporter=lcov npm run test",
     "debug": "npm run mocha -- \"tests/src/**/*.ts\" --reporter dot --timeout 60000",
     "lint": "eslint .",
@@ -105,6 +106,7 @@
     "eslint-plugin-regexp": "^2.0.0",
     "eslint-plugin-svelte": "^2.0.0",
     "eslint-plugin-yml": "^1.0.0",
+    "expect-type": "^0.19.0",
     "js-yaml": "^4.1.0",
     "less": "^4.1.2",
     "mocha": "^10.0.0",
@@ -120,7 +122,8 @@
     "sass": "^1.52.2",
     "stylus": "^0.63.0",
     "svelte": "^4.0.0",
-    "typescript": "~5.4.0"
+    "typescript": "~5.4.0",
+    "typescript-eslint": "^7.5.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,14 +10,15 @@ import flatRecommended from "./configs/flat/recommended"
 import flatAll from "./configs/flat/all"
 import { buildA11yConfigs } from "./a11y"
 import * as meta from "./meta"
+import type { Linter } from "eslint"
 
 const configs = {
-  base,
-  recommended,
-  all,
-  "flat/base": flatBase,
-  "flat/recommended": flatRecommended,
-  "flat/all": flatAll,
+  base: base as unknown as Linter.Config,
+  recommended: recommended as Linter.Config,
+  all: all as Linter.Config,
+  "flat/base": flatBase as Linter.FlatConfig[],
+  "flat/recommended": flatRecommended as Linter.FlatConfig[],
+  "flat/all": flatAll as Linter.FlatConfig[],
 }
 
 const a11yConfigs = buildA11yConfigs()

--- a/tests/typing.test.ts
+++ b/tests/typing.test.ts
@@ -1,0 +1,22 @@
+import type { Linter } from "eslint"
+import { expectTypeOf } from "expect-type"
+import tseslint from "typescript-eslint"
+import plugin from "../src/index"
+
+expectTypeOf([...plugin.configs["flat/base"]]).toMatchTypeOf<
+  Linter.FlatConfig[]
+>()
+expectTypeOf([...plugin.configs["flat/all"]]).toMatchTypeOf<
+  Linter.FlatConfig[]
+>()
+expectTypeOf([...plugin.configs["flat/recommended"]]).toMatchTypeOf<
+  Linter.FlatConfig[]
+>()
+
+tseslint.config(...plugin.configs["flat/base"])
+tseslint.config(...plugin.configs["flat/all"])
+tseslint.config(...plugin.configs["flat/recommended"])
+
+tseslint.config({ extends: [...plugin.configs["flat/base"]] })
+tseslint.config({ extends: [...plugin.configs["flat/all"]] })
+tseslint.config({ extends: [...plugin.configs["flat/recommended"]] })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
     "src/**/*",
     "tests/src/**/*",
     "tests/utils/**/*",
+    "tests/typing.test.ts",
     "tools/**/*",
     "docs-build/src/**/*.ts",
     "docs-build/src/**/*.astro",


### PR DESCRIPTION
Update the types to make the flat configs compatible with the [`config()` function of typescript-eslint](https://typescript-eslint.io/packages/typescript-eslint#config)  and the `Linter.FlatConfig` type of @types/eslint.
And add typing tests regarding that.
