### PR TITLE
fix: 🐛 correctly export `meta` for ESM types

### DIFF
--- a/.changeset/long-rats-divide.md
+++ b/.changeset/long-rats-divide.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-astro": patch
+---
+
+fix: 🐛 correctly export `meta` for ESM types

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,7 +1,7 @@
 import { rules as ruleList } from "./utils/rules"
 import * as processorsDefines from "./processor"
 import type { Rule } from "eslint"
-import * as meta from "./meta"
+import { name, version } from "./meta"
 import { environments } from "./environments"
 
 const rules = ruleList.reduce(
@@ -17,7 +17,7 @@ const processors = {
   "client-side-ts": processorsDefines.clientSideTsProcessor,
 }
 export const plugin = {
-  meta,
+  meta: { name, version },
   environments,
   rules,
   processors,

--- a/tests/fixtures/integration/config/tsconfig.json
+++ b/tests/fixtures/integration/config/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "allowJs": true
+  }
+}

--- a/tests/integration/test.ts
+++ b/tests/integration/test.ts
@@ -67,19 +67,7 @@ for (const dirent of fs.readdirSync(TEST_FIXTURES_ROOT, {
     })
 
     it("should NOT fail when running tsc", () => {
-      try {
-        cp.execSync(`npx tsc`, { cwd: TEST_CWD })
-
-        assert.fail("Expect error")
-      } catch (e: any) {
-        const result = `${e.stdout}`
-        try {
-          assert.equal(result, "undefined")
-        } catch (e) {
-          console.error(e)
-          throw e
-        }
-      }
+      cp.execSync(`npx tsc`, { cwd: TEST_CWD })
     })
   })
 }

--- a/tests/integration/test.ts
+++ b/tests/integration/test.ts
@@ -65,5 +65,21 @@ for (const dirent of fs.readdirSync(TEST_FIXTURES_ROOT, {
         }
       }
     })
+
+    it("should NOT fail when running tsc", () => {
+      try {
+        cp.execSync(`npx tsc`, { cwd: TEST_CWD })
+
+        assert.fail("Expect error")
+      } catch (e: any) {
+        const result = `${e.stdout}`
+        try {
+          assert.equal(result, "undefined")
+        } catch (e) {
+          console.error(e)
+          throw e
+        }
+      }
+    })
   })
 }


### PR DESCRIPTION
Not entirely sure why this is happening, but when we have:
```ts
import * as meta from "./meta"
```

It leads to:
```ts
declare const meta: typeof __metadeclare const rules: {
    [key: string]: eslint.Rule.RuleModule;
};
```

Which leads to a TypeScript error: `',' expected.ts(1005)`. 

Changing it to:
```ts
import { name, version } from "./meta"

export const plugin = {
  meta: { name, version },
  environments,
  rules,
  processors,
}
```

Leads to:
```ts
declare const meta: {
    name: string;
    version: string;
};
declare const rules: {
    [key: string]: eslint.Rule.RuleModule;
};
```
Which should be the correct output.
