### PR TITLE
feat: add name of config object

### DIFF
--- a/.changeset/angry-eels-count.md
+++ b/.changeset/angry-eels-count.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-astro": patch
+---
+
+feat: add name of config object

--- a/src/configs/flat/base.ts
+++ b/src/configs/flat/base.ts
@@ -12,6 +12,7 @@ import { environments } from "../../environments/index"
 let plugin: unknown
 export default [
   {
+    name: "eslint-plugin-astro/base/plugin",
     plugins: {
       get astro(): ESLint.Plugin {
         // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires -- ignore
@@ -20,6 +21,7 @@ export default [
     },
   },
   {
+    name: "eslint-plugin-astro/base",
     files: ["*.astro", "**/*.astro"],
     languageOptions: {
       globals: {
@@ -45,6 +47,7 @@ export default [
   {
     // Define the configuration for `<script>` tag.
     // Script in `<script>` is assigned a virtual file name with the `.js` extension.
+    name: "eslint-plugin-astro/base/javascript",
     files: ["**/*.astro/*.js", "*.astro/*.js"],
     languageOptions: {
       globals: {
@@ -61,6 +64,7 @@ export default [
   {
     // Define the configuration for `<script>` tag when using `client-side-ts` processor.
     // Script in `<script>` is assigned a virtual file name with the `.ts` extension.
+    name: "eslint-plugin-astro/base/typescript",
     files: ["**/*.astro/*.ts", "*.astro/*.ts"],
     languageOptions: {
       globals: {

--- a/src/configs/flat/base.ts
+++ b/src/configs/flat/base.ts
@@ -12,7 +12,7 @@ import { environments } from "../../environments/index"
 let plugin: unknown
 export default [
   {
-    name: "eslint-plugin-astro/base/plugin",
+    name: "astro/base/plugin",
     plugins: {
       get astro(): ESLint.Plugin {
         // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires -- ignore
@@ -21,7 +21,7 @@ export default [
     },
   },
   {
-    name: "eslint-plugin-astro/base",
+    name: "astro/base",
     files: ["*.astro", "**/*.astro"],
     languageOptions: {
       globals: {
@@ -47,7 +47,7 @@ export default [
   {
     // Define the configuration for `<script>` tag.
     // Script in `<script>` is assigned a virtual file name with the `.js` extension.
-    name: "eslint-plugin-astro/base/javascript",
+    name: "astro/base/javascript",
     files: ["**/*.astro/*.js", "*.astro/*.js"],
     languageOptions: {
       globals: {
@@ -64,7 +64,7 @@ export default [
   {
     // Define the configuration for `<script>` tag when using `client-side-ts` processor.
     // Script in `<script>` is assigned a virtual file name with the `.ts` extension.
-    name: "eslint-plugin-astro/base/typescript",
+    name: "astro/base/typescript",
     files: ["**/*.astro/*.ts", "*.astro/*.ts"],
     languageOptions: {
       globals: {

--- a/src/configs/flat/recommended.ts
+++ b/src/configs/flat/recommended.ts
@@ -5,6 +5,7 @@ import base from "./base"
 export default [
   ...base,
   {
+    name: "eslint-plugin-astro/recommended",
     rules: {
       // eslint-plugin-astro rules
       "astro/missing-client-only-directive-value": "error",

--- a/src/configs/flat/recommended.ts
+++ b/src/configs/flat/recommended.ts
@@ -5,7 +5,7 @@ import base from "./base"
 export default [
   ...base,
   {
-    name: "eslint-plugin-astro/recommended",
+    name: "astro/recommended",
     rules: {
       // eslint-plugin-astro rules
       "astro/missing-client-only-directive-value": "error",

--- a/tools/update-rulesets.ts
+++ b/tools/update-rulesets.ts
@@ -114,7 +114,7 @@ import { environments } from "../../environments/index"
 let plugin: unknown
 export default [
   {
-    name: 'eslint-plugin-astro/base/plugin',
+    name: 'astro/base/plugin',
     plugins: {
       get astro(): ESLint.Plugin {
         // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires -- ignore
@@ -123,7 +123,7 @@ export default [
     },
   },
   {
-    name: 'eslint-plugin-astro/base',
+    name: 'astro/base',
     files: ["*.astro", "**/*.astro"],
     languageOptions: {
       globals: {
@@ -153,7 +153,7 @@ export default [
   {
     // Define the configuration for \`<script>\` tag.
     // Script in \`<script>\` is assigned a virtual file name with the \`.js\` extension.
-    name: 'eslint-plugin-astro/base/javascript',
+    name: 'astro/base/javascript',
     files: ["**/*.astro/*.js", "*.astro/*.js"],
     languageOptions: {
       globals: {
@@ -170,7 +170,7 @@ export default [
   {
     // Define the configuration for \`<script>\` tag when using \`client-side-ts\` processor.
     // Script in \`<script>\` is assigned a virtual file name with the \`.ts\` extension.
-    name: 'eslint-plugin-astro/base/typescript',
+    name: 'astro/base/typescript',
     files: ["**/*.astro/*.ts", "*.astro/*.ts"],
     languageOptions: {
       globals: {
@@ -229,7 +229,7 @@ import base from './base';
 export default [
   ...base,
   {
-    name: 'eslint-plugin-astro/recommended',
+    name: 'astro/recommended',
     rules: {
       // eslint-plugin-astro rules
       ${recommendedRules

--- a/tools/update-rulesets.ts
+++ b/tools/update-rulesets.ts
@@ -114,6 +114,7 @@ import { environments } from "../../environments/index"
 let plugin: unknown
 export default [
   {
+    name: 'eslint-plugin-astro/base/plugin',
     plugins: {
       get astro(): ESLint.Plugin {
         // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires -- ignore
@@ -122,6 +123,7 @@ export default [
     },
   },
   {
+    name: 'eslint-plugin-astro/base',
     files: ["*.astro", "**/*.astro"],
     languageOptions: {
       globals: {
@@ -151,6 +153,7 @@ export default [
   {
     // Define the configuration for \`<script>\` tag.
     // Script in \`<script>\` is assigned a virtual file name with the \`.js\` extension.
+    name: 'eslint-plugin-astro/base/javascript',
     files: ["**/*.astro/*.js", "*.astro/*.js"],
     languageOptions: {
       globals: {
@@ -167,6 +170,7 @@ export default [
   {
     // Define the configuration for \`<script>\` tag when using \`client-side-ts\` processor.
     // Script in \`<script>\` is assigned a virtual file name with the \`.ts\` extension.
+    name: 'eslint-plugin-astro/base/typescript',
     files: ["**/*.astro/*.ts", "*.astro/*.ts"],
     languageOptions: {
       globals: {
@@ -225,6 +229,7 @@ import base from './base';
 export default [
   ...base,
   {
+    name: 'eslint-plugin-astro/recommended',
     rules: {
       // eslint-plugin-astro rules
       ${recommendedRules


### PR DESCRIPTION
ESLint config objects can be specified by name.
https://github.com/eslint/rfcs/blob/main/designs/2019-config-simplification/README.md#the-eslintconfigjs-file

This is used by tools such as https://github.com/eslint/config-inspector to give hints to ESLint users.

| AS-IS | TO-BE |
|-|-|
|<img width="1512" alt=" 2024-05-12 19 19 51" src="https://github.com/ota-meshi/eslint-plugin-astro/assets/6040962/4959e18d-f484-43ea-88d5-99d9fa39c5bd">|<img width="1512" alt=" 2024-05-12 19 27 10" src="https://github.com/ota-meshi/eslint-plugin-astro/assets/6040962/04db219b-f8e8-45be-a807-4cfe26386c44">|

There may be more obvious candidates for the name.

The following are examples of other projects that employ the name property.
- https://github.com/typescript-eslint/typescript-eslint/blob/7ce6acd3bf4532855512e3aa03a15b603f56a84a/packages/typescript-eslint/src/configs/recommended.ts#L20
- https://github.com/nuxt/eslint/blob/7438c58ca01c4e4004c40ffbed0f5aef7c4d808a/packages/eslint-config/src/flat/configs/nuxt.ts#L20
