### PR TITLE
Update no-exports-from-components rule to allow exceptions

### DIFF
--- a/docs/rules/no-exports-from-components.md
+++ b/docs/rules/no-exports-from-components.md
@@ -13,6 +13,10 @@ since: "v1.1.0"
 This rule reports value exports from Astro components.
 The use of typed exports are still allowed.
 
+However, there are exceptions for specific named exports that are allowed:
+- `getStaticPath`: This function can be exported for dynamic routing purposes.
+- `prerender`: This constant can be exported to opt-in to pre-rendering in server mode.
+
 <ESLintCodeBlock>
 
 <!--eslint-skip-->
@@ -22,6 +26,10 @@ The use of typed exports are still allowed.
 /* eslint astro/no-exports-from-components: "error" */
 /* ✓ GOOD */
 export type A = number | boolean
+export const getStaticPath = () => {
+  // logic here
+}
+export const prerender = true;
 /* ✗ BAD */
 export const x = 42
 ---

--- a/src/rules/no-exports-from-components.ts
+++ b/src/rules/no-exports-from-components.ts
@@ -57,6 +57,10 @@ export default createRule("no-exports-from-components", {
         verifyDeclaration(node.declaration)
         for (const spec of node.specifiers) {
           if (spec.exportKind === "type") return
+          if (["getStaticPath", "prerender"].includes(spec.exported.name)) {
+            // Allow specific named exports
+            return
+          }
           context.report({
             node: spec,
             messageId: "disallowExport",

--- a/tests/fixtures/rules/no-exports-from-components/valid/exceptions-02-input.astro
+++ b/tests/fixtures/rules/no-exports-from-components/valid/exceptions-02-input.astro
@@ -1,0 +1,7 @@
+---
+// This file is used to test the exception for the `getStaticPath` function in the `no-exports-from-components` rule.
+export async function getStaticPath() {
+  // logic here
+}
+---
+<div>Hello World</div>

--- a/tests/fixtures/rules/no-exports-from-components/valid/exceptions-input.astro
+++ b/tests/fixtures/rules/no-exports-from-components/valid/exceptions-input.astro
@@ -1,0 +1,9 @@
+---
+// This file is used to test the exceptions for the `no-exports-from-components` rule.
+// The following exports are allowed as exceptions.
+export const getStaticPath = () => {
+  // logic here
+}
+export const prerender = true;
+---
+<div>Hello World</div>


### PR DESCRIPTION
Related to #385

Updates the `no-exports-from-components` rule to include exceptions for `getStaticPath` and `prerender` named exports, and enhances documentation and tests accordingly.
- Modifies the rule implementation in `src/rules/no-exports-from-components.ts` to allow `getStaticPath` and `prerender` as named exports, while still disallowing other value exports.
- Updates the documentation in `docs/rules/no-exports-from-components.md` to mention these exceptions and provide examples of allowed and disallowed exports.
- Adds test case fixtures in `tests/fixtures/rules/no-exports-from-components/valid/` to verify the rule correctly allows the exceptions.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ota-meshi/eslint-plugin-astro/issues/385?shareId=102e3975-f4d0-4aae-bbca-41d69b1b84a2).