### PR TITLE
feat: support typescript-eslint@8

### DIFF
--- a/.changeset/late-dancers-guess.md
+++ b/.changeset/late-dancers-guess.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-astro": patch
+---
+
+feat: support typescript-eslint@8

--- a/docs-build/src/components/eslint/MonacoEditor.svelte
+++ b/docs-build/src/components/eslint/MonacoEditor.svelte
@@ -54,7 +54,7 @@
     }
   }
   $: {
-    // eslint-disable-next-line no-unused-expressions -- reactive
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- reactive
     language
     disposeCodeActionProvider()
     if (provideCodeActions) {
@@ -78,7 +78,7 @@
     }
   }
   $: {
-    // eslint-disable-next-line no-unused-expressions -- reactive
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- reactive
     language
     // Set the language to the current editors.
     for (const editor of [getLeftEditor?.(), getRightEditor?.()]) {

--- a/docs-build/src/components/eslint/scripts/linter.mts
+++ b/docs-build/src/components/eslint/scripts/linter.mts
@@ -3,6 +3,7 @@ import type { Linter, Rule } from "eslint"
 import { builtinRules } from "eslint/use-at-your-own-risk"
 import * as astroEslintParser from "astro-eslint-parser"
 import * as processors from "../../../../../src/processor/index.js"
+import type { RuleModule } from "../../../../../src/types.js"
 import globals from "globals"
 
 export const categories: {
@@ -72,12 +73,19 @@ export const categories: {
 ]
 export const DEFAULT_RULES_CONFIG: Record<string, string> = {}
 
-const rules = []
+interface DocsRuleLike {
+  ruleId: string
+  rule: RuleModule | Rule.RuleModule
+  classes: string
+  url: string | undefined
+}
+
+const rules: DocsRuleLike[] = []
 for (const rule of pluginRules) {
   if (rule.meta.deprecated) {
     continue
   }
-  const data = {
+  const data: DocsRuleLike = {
     ruleId: rule.meta.docs.ruleId,
     rule,
     classes: "svelte-rule",
@@ -96,7 +104,7 @@ for (const [ruleId, rule] of builtinRules) {
   if (rule.meta!.deprecated) {
     continue
   }
-  const data = {
+  const data: DocsRuleLike = {
     ruleId,
     rule,
     classes: "core-rule",
@@ -132,7 +140,7 @@ export function rulesMap(): Map<string, Rule.RuleModule> {
   ])
 }
 
-export async function createLinterConfig(): Promise<Linter.FlatConfig[]> {
+export async function createLinterConfig(): Promise<Linter.Config[]> {
   const tsParser = await import("@typescript-eslint/parser")
 
   await (astroEslintParser as any).setup()
@@ -141,6 +149,7 @@ export async function createLinterConfig(): Promise<Linter.FlatConfig[]> {
       files: ["**"],
       plugins: {
         astro: {
+          // @ts-expect-error -- typing bug
           rules: Object.fromEntries(
             pluginRules.map((rule) => [rule.meta.docs.ruleName, rule]),
           ) as Record<string, Rule.RuleModule>,

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -161,6 +161,7 @@ module.exports = [
         "one-var": "off",
         "func-style": "off",
         "@typescript-eslint/no-empty-function": "off",
+        "@typescript-eslint/no-empty-object-type": "off",
         "prefer-const": "off",
         "@typescript-eslint/no-unused-vars": "off",
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@eslint-community/eslint-utils": "^4.2.0",
     "@jridgewell/sourcemap-codec": "^1.4.14",
-    "@typescript-eslint/types": "^7.7.1",
+    "@typescript-eslint/types": "^7.7.1 || ^8",
     "astro-eslint-parser": "^1.0.2",
     "eslint-compat-utils": "^0.5.0",
     "globals": "^15.0.0",
@@ -96,8 +96,8 @@
     "@types/react": "^18.0.15",
     "@types/semver": "^7.3.9",
     "@types/stylus": "^0.48.38",
-    "@typescript-eslint/eslint-plugin": "^7.7.1",
-    "@typescript-eslint/parser": "^7.7.1",
+    "@typescript-eslint/eslint-plugin": "^8.5.0",
+    "@typescript-eslint/parser": "^8.5.0",
     "assert": "^2.0.0",
     "astro": "^4.5.0",
     "env-cmd": "^10.1.0",
@@ -105,7 +105,7 @@
     "esbuild-register": "^3.3.3",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^9.0.0",
-    "eslint-plugin-astro": "^1.0.2",
+    "eslint-plugin-astro": "^1.2.3",
     "eslint-plugin-eslint-plugin": "^6.0.0",
     "eslint-plugin-jsdoc": "^50.0.0",
     "eslint-plugin-json-schema-validator": "^5.0.0",
@@ -136,7 +136,7 @@
     "svelte": "^4.0.0",
     "tsup": "^8.0.2",
     "typescript": "~5.4.0",
-    "typescript-eslint": "^7.5.0",
+    "typescript-eslint": "^8.5.0",
     "vite-plugin-eslint4b": "^0.4.0"
   },
   "publishConfig": {

--- a/src/a11y/configs.ts
+++ b/src/a11y/configs.ts
@@ -4,8 +4,8 @@ import flatBase from "../configs/flat/base"
 import type { Linter } from "eslint"
 
 /** Build a11y configs */
-export function buildFlatConfigs(): Record<string, Linter.FlatConfig[]> {
-  const configs: Record<string, Linter.FlatConfig[]> = {}
+export function buildFlatConfigs(): Record<string, Linter.Config[]> {
+  const configs: Record<string, Linter.Config[]> = {}
 
   for (const configName of a11yConfigKeys) {
     // flat config

--- a/src/a11y/index.ts
+++ b/src/a11y/index.ts
@@ -9,7 +9,7 @@ export function buildA11yRules(): RuleModule[] {
 }
 
 /** Build a11y configs */
-export function buildA11yFlatConfigs(): Record<string, Linter.FlatConfig[]> {
+export function buildA11yFlatConfigs(): Record<string, Linter.Config[]> {
   return buildFlatConfigs()
 }
 

--- a/src/cjs-config-builder.ts
+++ b/src/cjs-config-builder.ts
@@ -8,16 +8,16 @@ import { buildA11yFlatConfigs, buildA11yLegacyConfigs } from "./a11y"
 import type { Linter } from "eslint"
 
 type CJSConfigs = {
-  base: Linter.Config
-  recommended: Linter.Config
-  all: Linter.Config
-  "jsx-a11y-strict": Linter.Config
-  "jsx-a11y-recommended": Linter.Config
-  "flat/base": Linter.FlatConfig[]
-  "flat/recommended": Linter.FlatConfig[]
-  "flat/all": Linter.FlatConfig[]
-  "flat/jsx-a11y-strict": Linter.FlatConfig[]
-  "flat/jsx-a11y-recommended": Linter.FlatConfig[]
+  base: Linter.LegacyConfig
+  recommended: Linter.LegacyConfig
+  all: Linter.LegacyConfig
+  "jsx-a11y-strict": Linter.LegacyConfig
+  "jsx-a11y-recommended": Linter.LegacyConfig
+  "flat/base": Linter.Config[]
+  "flat/recommended": Linter.Config[]
+  "flat/all": Linter.Config[]
+  "flat/jsx-a11y-strict": Linter.Config[]
+  "flat/jsx-a11y-recommended": Linter.Config[]
 }
 
 /**
@@ -26,15 +26,15 @@ type CJSConfigs = {
 export function buildCjsConfigs(): CJSConfigs {
   const cjsConfigs: CJSConfigs = {
     base: buildLegacyBase(),
-    recommended: recommended as Linter.Config,
-    all: all as Linter.Config,
-    "jsx-a11y-strict": null as never as Linter.Config,
-    "jsx-a11y-recommended": null as never as Linter.Config,
-    "flat/base": flatBase as Linter.FlatConfig[],
-    "flat/recommended": flatRecommended as Linter.FlatConfig[],
-    "flat/all": flatAll as Linter.FlatConfig[],
-    "flat/jsx-a11y-strict": null as never as Linter.FlatConfig[],
-    "flat/jsx-a11y-recommended": null as never as Linter.FlatConfig[],
+    recommended: recommended as Linter.LegacyConfig,
+    all: all as Linter.LegacyConfig,
+    "jsx-a11y-strict": null as never as Linter.LegacyConfig,
+    "jsx-a11y-recommended": null as never as Linter.LegacyConfig,
+    "flat/base": flatBase as Linter.Config[],
+    "flat/recommended": flatRecommended as Linter.Config[],
+    "flat/all": flatAll as Linter.Config[],
+    "flat/jsx-a11y-strict": null as never as Linter.Config[],
+    "flat/jsx-a11y-recommended": null as never as Linter.Config[],
   }
 
   const a11yFlatConfigs = buildA11yFlatConfigs()

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -7,7 +7,7 @@ import { hasTypescriptEslintParser } from "./has-typescript-eslint-parser"
 /**
  * Build legacy base config
  */
-export function buildLegacyBase(): Linter.Config {
+export function buildLegacyBase(): Linter.LegacyConfig {
   return {
     plugins: ["astro"],
     overrides: [

--- a/src/esm-config-builder.ts
+++ b/src/esm-config-builder.ts
@@ -5,32 +5,32 @@ import { buildA11yFlatConfigs } from "./a11y"
 import type { Linter } from "eslint"
 
 type ESMConfigs = {
-  base: Linter.FlatConfig[]
-  recommended: Linter.FlatConfig[]
-  all: Linter.FlatConfig[]
-  "jsx-a11y-strict": Linter.FlatConfig[]
-  "jsx-a11y-recommended": Linter.FlatConfig[]
+  base: Linter.Config[]
+  recommended: Linter.Config[]
+  all: Linter.Config[]
+  "jsx-a11y-strict": Linter.Config[]
+  "jsx-a11y-recommended": Linter.Config[]
   // For backward compatibility
-  "flat/base": Linter.FlatConfig[]
-  "flat/recommended": Linter.FlatConfig[]
-  "flat/all": Linter.FlatConfig[]
-  "flat/jsx-a11y-strict": Linter.FlatConfig[]
-  "flat/jsx-a11y-recommended": Linter.FlatConfig[]
+  "flat/base": Linter.Config[]
+  "flat/recommended": Linter.Config[]
+  "flat/all": Linter.Config[]
+  "flat/jsx-a11y-strict": Linter.Config[]
+  "flat/jsx-a11y-recommended": Linter.Config[]
 }
 /**
  * Build configs for ESM Module
  */
 export function buildEsmConfigs(): ESMConfigs {
   const esmConfigs: ESMConfigs = {
-    base: flatBase as Linter.FlatConfig[],
-    recommended: flatRecommended as Linter.FlatConfig[],
-    all: flatAll as Linter.FlatConfig[],
+    base: flatBase as Linter.Config[],
+    recommended: flatRecommended as Linter.Config[],
+    all: flatAll as Linter.Config[],
     "jsx-a11y-strict": null as never,
     "jsx-a11y-recommended": null as never,
     // For backward compatibility
-    "flat/base": flatBase as Linter.FlatConfig[],
-    "flat/recommended": flatRecommended as Linter.FlatConfig[],
-    "flat/all": flatAll as Linter.FlatConfig[],
+    "flat/base": flatBase as Linter.Config[],
+    "flat/recommended": flatRecommended as Linter.Config[],
+    "flat/all": flatAll as Linter.Config[],
     "flat/jsx-a11y-strict": null as never,
     "flat/jsx-a11y-recommended": null as never,
   }

--- a/src/rules/no-unused-css-selector.ts
+++ b/src/rules/no-unused-css-selector.ts
@@ -62,7 +62,7 @@ export default createRule("no-unused-css-selector", {
       let root
       try {
         root = postcss.parse(css.css)
-      } catch (_e) {
+      } catch {
         return
       }
       const ignoreNodes = new Set<PostcssNode>()

--- a/src/utils/transform/less.ts
+++ b/src/utils/transform/less.ts
@@ -46,7 +46,7 @@ export function transform(
       output: output.css,
       mappings: JSON.parse(output.map).mappings,
     }
-  } catch (_e) {
+  } catch {
     return null
   }
 }

--- a/src/utils/transform/postcss.ts
+++ b/src/utils/transform/postcss.ts
@@ -42,8 +42,7 @@ export function transform(
       output: result.content,
       mappings: result.map.toJSON().mappings,
     }
-  } catch (_e) {
-    // console.log(_e)
+  } catch {
     return null
   }
 }

--- a/src/utils/transform/sass.ts
+++ b/src/utils/transform/sass.ts
@@ -35,7 +35,7 @@ export function transform(
       output: output.css,
       mappings: output.sourceMap!.mappings,
     }
-  } catch (_e) {
+  } catch {
     return null
   }
 }

--- a/src/utils/transform/stylus.ts
+++ b/src/utils/transform/stylus.ts
@@ -41,7 +41,7 @@ export function transform(
       mappings: (style as unknown as { sourcemap: RawSourceMap }).sourcemap
         .mappings,
     }
-  } catch (_e) {
+  } catch {
     return null
   }
 }

--- a/tests/src/config/recommended.ts
+++ b/tests/src/config/recommended.ts
@@ -19,6 +19,7 @@ describe("`recommended` config", () => {
         astro: plugin as never,
       },
       baseConfig: {
+        // @ts-expect-error -- typing bug
         parserOptions: {
           ecmaVersion: 2020,
         },
@@ -46,9 +47,7 @@ describe("`recommended` config", () => {
   })
   it("`flat/recommended` config should work. ", async () => {
     const linter = new FlatESLint({
-      // @ts-expect-error -- typing bug
       overrideConfigFile: true,
-      // @ts-expect-error -- typing bug
       overrideConfig: [...plugin.configs["flat/recommended"]],
     })
     const result = await linter.lintText(code, { filePath: "test.astro" })
@@ -71,9 +70,7 @@ describe("`recommended` config", () => {
   })
   it("`flat/recommended` config with *.js should work. ", async () => {
     const linter = new FlatESLint({
-      // @ts-expect-error -- typing bug
       overrideConfigFile: true,
-      // @ts-expect-error -- typing bug
       overrideConfig: [...plugin.configs["flat/recommended"]],
     })
 

--- a/tests/src/integration/client-javascript.ts
+++ b/tests/src/integration/client-javascript.ts
@@ -28,6 +28,7 @@ describe("Integration test for client-side script", () => {
           },
           useEslintrc: false,
           overrideConfig: {
+            // @ts-expect-error -- typing bug
             extends: ["plugin:astro/base"],
             rules: {
               "no-restricted-syntax": ["error", "Identifier[name='id']"],
@@ -36,7 +37,6 @@ describe("Integration test for client-side script", () => {
         })
       : new ESLint({
           overrideConfigFile: true as any,
-          // @ts-expect-error -- typing bug
           overrideConfig: [
             ...astroPlugin.configs["flat/base"],
             {

--- a/tests/src/integration/client-typescript.ts
+++ b/tests/src/integration/client-typescript.ts
@@ -29,6 +29,7 @@ describe("Integration test for client-side ts", () => {
           },
           useEslintrc: false,
           overrideConfig: {
+            // @ts-expect-error -- typing bug
             extends: ["plugin:astro/base"],
             parser: "@typescript-eslint/parser",
             rules: {
@@ -49,11 +50,12 @@ describe("Integration test for client-side ts", () => {
         })
       : new ESLint({
           overrideConfigFile: true as any,
-          // @ts-expect-error -- typing bug
           overrideConfig: [
+            // @ts-expect-error -- typing bug
             ...astroPlugin.configs["flat/base"],
             {
               files: ["*.ts", "**/*.ts"],
+              // @ts-expect-error -- typing bug
               languageOptions: {
                 parser: tsESLintParser,
               },

--- a/tests/src/integration/config-for-a11y.ts
+++ b/tests/src/integration/config-for-a11y.ts
@@ -31,12 +31,12 @@ describe("Integration test for a11y config", () => {
           },
           useEslintrc: false,
           overrideConfig: {
+            // @ts-expect-error -- typing bug
             extends: ["plugin:astro/jsx-a11y-strict"],
           },
         })
       : new ESLint({
           overrideConfigFile: true as any,
-          // @ts-expect-error -- typing bug
           overrideConfig: astroPlugin.configs["flat/jsx-a11y-strict"],
         })
 
@@ -80,12 +80,12 @@ const src = 'icon.png'
           },
           useEslintrc: false,
           overrideConfig: {
+            // @ts-expect-error -- typing bug
             extends: ["plugin:astro/jsx-a11y-recommended"],
           },
         })
       : new ESLint({
           overrideConfigFile: true as any,
-          // @ts-expect-error -- typing bug
           overrideConfig: astroPlugin.configs["flat/jsx-a11y-recommended"],
         })
 

--- a/tests/src/integration/parse-error.ts
+++ b/tests/src/integration/parse-error.ts
@@ -28,12 +28,12 @@ describe("Integration test for parse error", () => {
           },
           useEslintrc: false,
           overrideConfig: {
+            // @ts-expect-error -- typing bug
             extends: ["plugin:astro/base"],
           },
         })
       : new ESLint({
           overrideConfigFile: true as any,
-          // @ts-expect-error -- typing bug
           overrideConfig: astroPlugin.configs["flat/base"],
         })
 

--- a/tests/typing.test.ts
+++ b/tests/typing.test.ts
@@ -3,14 +3,10 @@ import { expectTypeOf } from "expect-type"
 import tseslint from "typescript-eslint"
 import * as plugin from "../src/index.mts"
 
-expectTypeOf([...plugin.configs["flat/base"]]).toMatchTypeOf<
-  Linter.FlatConfig[]
->()
-expectTypeOf([...plugin.configs["flat/all"]]).toMatchTypeOf<
-  Linter.FlatConfig[]
->()
+expectTypeOf([...plugin.configs["flat/base"]]).toMatchTypeOf<Linter.Config[]>()
+expectTypeOf([...plugin.configs["flat/all"]]).toMatchTypeOf<Linter.Config[]>()
 expectTypeOf([...plugin.configs["flat/recommended"]]).toMatchTypeOf<
-  Linter.FlatConfig[]
+  Linter.Config[]
 >()
 
 tseslint.config(...plugin.configs["flat/base"])

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -96,7 +96,7 @@ export function loadTestCases(
       let errors
       try {
         errors = fs.readFileSync(errorFile, "utf8")
-      } catch (_e) {
+      } catch {
         writeFixtures(ruleName, inputFile)
         errors = fs.readFileSync(errorFile, "utf8")
       }
@@ -105,7 +105,7 @@ export function loadTestCases(
         let output
         try {
           output = fs.readFileSync(outputFile, "utf8")
-        } catch (_e) {
+        } catch {
           writeFixtures(ruleName, inputFile)
           output = fs.readFileSync(outputFile, "utf8")
         }


### PR DESCRIPTION
This doesn't generally change any `.js` or `.ts` source files - just version ranges, comments, and type annotations. The only functional changes are removing unused `_e`s from `catch (_e) {` blocks, now that that's enabled by default in `@typescript-eslint/no-unused-vars`: https://typescript-eslint.io/blog/announcing-typescript-eslint-v8#rule-breaking-changes.

Fixes #404.