### PR TITLE
chore: remove redundant assignments & use "createRequire"

### DIFF
--- a/tools/lib/load-rules.ts
+++ b/tools/lib/load-rules.ts
@@ -1,27 +1,21 @@
 import path from "path"
 import fs from "fs"
+import { createRequire } from "module"
+import type { RuleModule } from "../../src/types"
+
+const url = import.meta.url
+const require = createRequire(url)
 
 /**
- * Get the all rules
- * @returns {Array} The all rules
+ * Import all rules from `src/rules` and return them as an array.
+ * @returns {RuleModule[]}
  */
-function readRules() {
-  const rulesLibRoot = path.resolve(__dirname, "../../src/rules")
-  const rules = []
-  for (const name of fs
-    .readdirSync(rulesLibRoot)
-    .filter((n) => n.endsWith(".ts"))) {
-    const ruleName = name.replace(/\.ts$/u, "")
-    const ruleId = `astro/${ruleName}`
-    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports -- ignore
-    const rule = require(path.join(rulesLibRoot, name)).default
-
-    rule.meta.docs.ruleName = ruleName
-    rule.meta.docs.ruleId = ruleId
-
-    rules.push(rule)
-  }
-  return rules
+function readRules(): RuleModule[] {
+  const rulesPath = path.resolve(__dirname, "../../src/rules")
+  return fs
+    .readdirSync(rulesPath)
+    .filter((n) => n.endsWith(".ts"))
+    .map((fileName) => require(path.join(rulesPath, fileName)).default)
 }
 
 export const rules = readRules()


### PR DESCRIPTION
### Redundant Assignments:

These lines are no longer needed because these fields are added by `createRule` function when the rules are initialized
```
rule.meta.docs.ruleName = ruleName
rule.meta.docs.ruleId = ruleId
```
### Make it more ES module by using `createRequire`:

- No longer suppress the ESLint, the ESLint was warned for using `require` in a ts file. [@typescript-eslint/no-require-imports](https://typescript-eslint.io/rules/no-require-imports)

## Points to discuss:

Dear @ota-meshi, I think it's better to abandon this file and create an index file in the `src/rules` module:

- To take a step forward in making this package compatible with Bun/Deno
- ESModule import loads modules asynchronously behind the scenes, so it’s faster than using this module loader, the rules files will be loaded in parallel by the runtime ([Ref](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#description))
- The new index file is more familiar to developers who are not from the CommonJS era → Welcoming new contributors
- The src/rules files export as ES modules, so importing them as ES modules is ideal

  If you agree with these points, I’ll close this and create a new PR for the index file. You can preview the commit for the index file at [my fork here](https://github.com/Foxeye-Rinx/eslint-plugin-astro/commit/7ca2637cf0d6d83952c7c2bd3f00773bfbb59b4e)