### PR TITLE
Docs: Remove deprecated `--ext`

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -299,12 +299,11 @@ Ensure that any necessary parserOptions in your `.eslintrc.**` have a project ke
 
 ### Running ESLint from the command line
 
-If you want to run `eslint` from the command line, make sure you include the `.astro` extension using [the `--ext` option](https://eslint.org/docs/user-guide/configuring#specifying-file-extensions-to-lint) or a glob pattern, because ESLint targets only `.js` files by default.
+If you want to run `eslint` from the command line, make sure you include the `.astro` extension using a glob pattern, because ESLint targets only `.js` files by default.
 
-Examples:
+Example:
 
 ```bash
-eslint --ext .js,.astro src
 eslint "src/**/*.{js,astro}"
 ```
 


### PR DESCRIPTION
It looks to me the docs now reflect the eslint 9 setup. In this case, the `--ext` flag should not be recommended anymore.

```
% npx eslint --ext .js,.astro src
Invalid option '--ext' - perhaps you meant '-c'?
You're using eslint.config.js, some command line flags are no longer available. Please see https://eslint.org/docs/latest/use/command-line-interface for details.
```

From https://eslint.org/docs/latest/use/configure/migration-guide#--ext

> The --ext flag was used to specify additional file extensions ESLint should search for when a directory was passed on the command line, such as npx eslint .. This is no longer supported when using flat config. Instead, specify the file patterns you’d like ESLint to search for directly in your config.