### PR TITLE
fixtures/integration/config: fix package name

### DIFF
--- a/tests/fixtures/integration/config/package.json
+++ b/tests/fixtures/integration/config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-plugin-astro-integration-test-for-legacy-config",
+  "name": "eslint-plugin-astro-integration-test-for-config",
   "version": "1.0.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
It looks like the package name was previously copy/pasted from `tests/fixtures/integration/legacy-config/package.json`.