### PR TITLE
docs: fix sort-attributes docs page

### DIFF
--- a/docs/rules/sort-attributes.md
+++ b/docs/rules/sort-attributes.md
@@ -26,6 +26,7 @@ Default:
 
 ```astro
 ---
+/* eslint astro/sort-attributes: "error" */
 ---
 
 {/* ✓ GOOD */}

--- a/docs/rules/sort-attributes.md
+++ b/docs/rules/sort-attributes.md
@@ -10,7 +10,7 @@ since: "v1.3.0"
 
 - 🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
-## :book: Rule Details
+## 📖 Rule Details
 
 Maintaining a consistent order of attributes in Astro elements is crucial for readability and maintainability. This rule ensures that attributes are sorted, making the structure of your elements more predictable and easier to manage.
 
@@ -37,7 +37,7 @@ Default:
 
 </ESLintCodeBlock>
 
-## :wrench: Options
+## 🔧 Options
 
 ```json
 {
@@ -47,16 +47,6 @@ Default:
   ]
 }
 ```
-
-## :rocket: Version
-
-This rule was introduced in eslint-plugin-astro v1.3.0
-
-## :mag: Implementation
-
-- [Rule source](https://github.com/ota-meshi/eslint-plugin-astro/blob/main/src/rules/sort-attributes.ts)
-- [Test source](https://github.com/ota-meshi/eslint-plugin-astro/blob/main/tests/src/rules/sort-attributes.ts)
-- [Test fixture sources](https://github.com/ota-meshi/eslint-plugin-astro/tree/main/tests/fixtures/rules/sort-attributes)
 
 ## 🚀 Version
 


### PR DESCRIPTION
- Fix header icons
- Remove duplicated sections
- Fix example

Full page screenshots
|Before|After|
|-------|-----|
|![2025-01-12 19 34 09 ota-meshi github io 7b12875a79b8](https://github.com/user-attachments/assets/f1692edb-ce7a-4f10-b3e8-3cec7c59924c)|![2025-01-12 19 33 40 localhost c4ce7d925764](https://github.com/user-attachments/assets/b85335f5-18ea-4174-abcd-44112272443b)|