### PR TITLE
fix: incompatibility with `eslint-plugin-jsx-a11y`

### DIFF
--- a/src/a11y/configs.ts
+++ b/src/a11y/configs.ts
@@ -24,7 +24,7 @@ export function buildFlatConfigs(): Record<string, Linter.Config[]> {
         return [
           ...flatBase,
           {
-            plugins: { "jsx-a11y": base },
+            plugins: { "astro/jsx-a11y": base },
             rules: newRules,
           },
         ]

--- a/tests/src/config/recommended.ts
+++ b/tests/src/config/recommended.ts
@@ -19,7 +19,6 @@ describe("`recommended` config", () => {
         astro: plugin as never,
       },
       baseConfig: {
-        // @ts-expect-error -- typing bug
         parserOptions: {
           ecmaVersion: 2020,
         },

--- a/tests/src/integration/config-for-a11y.ts
+++ b/tests/src/integration/config-for-a11y.ts
@@ -26,7 +26,7 @@ describe("Integration test for a11y config", () => {
     const eslint = semver.lt(ESLint.version, "9.0.0-0")
       ? new ESLint({
           plugins: {
-            "jsx-a11y": jsxA11yPlugin,
+            "astro/jsx-a11y": jsxA11yPlugin,
             astro: astroPlugin as any,
           },
           useEslintrc: false,
@@ -75,7 +75,7 @@ const src = 'icon.png'
     const eslint = semver.lt(ESLint.version, "9.0.0-0")
       ? new ESLint({
           plugins: {
-            "jsx-a11y": jsxA11yPlugin,
+            "astro/jsx-a11y": jsxA11yPlugin,
             astro: astroPlugin as any,
           },
           useEslintrc: false,

--- a/tests/utils/eslint-compat.ts
+++ b/tests/utils/eslint-compat.ts
@@ -1,9 +1,9 @@
 import type { ESLint as OriginalESLint } from "eslint"
 import { getRuleIdPrefix, getRuleTester } from "eslint-compat-utils/rule-tester"
-import { getLegacyESLint, getESLint } from "eslint-compat-utils/eslint"
+import { getLegacyESLint, getESLint, LegacyESLint as OriginalLegacyESLint } from "eslint-compat-utils/eslint"
 
 // eslint-disable-next-line @typescript-eslint/naming-convention -- class name
-export const LegacyESLint: typeof OriginalESLint = getLegacyESLint()
+export const LegacyESLint: OriginalLegacyESLint = getLegacyESLint()
 // eslint-disable-next-line @typescript-eslint/naming-convention -- class name
 export const RuleTester = getRuleTester()
 export const testRuleIdPrefix = getRuleIdPrefix()


### PR DESCRIPTION
As described in #466 the plugin is not compatible when using both `eslint-plugin-astro` and  `eslint-plugin-jsx-a11y` because of the redefinition of `jsx-a11y` plugin. This PR resolves the issue by renaming the `jsx-a11y` plugin defined by `eslint-plugin-astro` to `astro/jsx-a11y`.

The only concern I have is regarding: https://github.com/ota-meshi/eslint-plugin-astro/blob/054461d3e99c50d494f12f5bdd0ef81531c792f7/src/a11y/configs.ts#L59

I believe it should be changed to `astro`, but since my tests did not show any error, I left it unchanged for now.

I have tested this change in a small repository with both ESLint 9.35.0  and 8.57.1, and everything appears to be working correctly.

Fixes #466.