### PR TITLE
feat: add `prefer-astro-zod-import` rule

### DIFF
--- a/.changeset/prefer-astro-zod-import.md
+++ b/.changeset/prefer-astro-zod-import.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-astro": minor
+---
+
+Add new rule `astro/prefer-astro-zod-import` that enforces importing Zod from `astro/zod` instead of the standalone `zod` package, keeping consumer code in sync with the Zod version bundled with Astro. Auto-fixes `zod`, `zod/v4`, and `zod/v4-mini` to `astro/zod`; reports without auto-fix for `zod/v3` and `zod/locales/*` because those subpaths are not re-exported.

--- a/.changeset/prefer-astro-zod-import.md
+++ b/.changeset/prefer-astro-zod-import.md
@@ -2,4 +2,4 @@
 "eslint-plugin-astro": minor
 ---
 
-Add new rule `astro/prefer-astro-zod-import` that enforces importing Zod from `astro/zod` instead of the standalone `zod` package, keeping consumer code in sync with the Zod version bundled with Astro. Auto-fixes `zod`, `zod/v4`, and `zod/v4-mini` to `astro/zod`; reports without auto-fix for `zod/v3` and `zod/locales/*` because those subpaths are not re-exported.
+Add new rule `astro/prefer-astro-zod-import` that enforces importing Zod from `astro/zod` instead of the standalone `zod` package, keeping consumer code in sync with the Zod version bundled with Astro. Covers `import` / re-`export` declarations, dynamic `import()` expressions, and TypeScript `import(...)` type queries. Auto-fixes `zod`, `zod/v4`, and `zod/v4-mini` to `astro/zod`; reports without auto-fix for `zod/v3` and `zod/locales/*` because those subpaths are not re-exported.

--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ These rules relate to better ways of doing things to help you avoid problems:
 |:--------|:------------|:---|
 | [astro/no-set-text-directive](https://ota-meshi.github.io/eslint-plugin-astro/rules/no-set-text-directive/) | disallow use of `set:text` | 🔧 |
 | [astro/no-unused-css-selector](https://ota-meshi.github.io/eslint-plugin-astro/rules/no-unused-css-selector/) | disallow selectors defined in `style` tag that don't use in HTML |  |
+| [astro/prefer-astro-zod-import](https://ota-meshi.github.io/eslint-plugin-astro/rules/prefer-astro-zod-import/) | enforce importing Zod from `astro/zod` to stay in sync with the version bundled with Astro | 🔧 |
 
 ## Stylistic Issues
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -41,6 +41,7 @@ These rules relate to better ways of doing things to help you avoid problems:
 |:--------|:------------|:---|
 | [astro/no-set-text-directive](./rules/no-set-text-directive.md) | disallow use of `set:text` | 🔧 |
 | [astro/no-unused-css-selector](./rules/no-unused-css-selector.md) | disallow selectors defined in `style` tag that don't use in HTML |  |
+| [astro/prefer-astro-zod-import](./rules/prefer-astro-zod-import.md) | enforce importing Zod from `astro/zod` to stay in sync with the version bundled with Astro | 🔧 |
 
 ## Stylistic Issues
 

--- a/docs/rules/prefer-astro-zod-import.md
+++ b/docs/rules/prefer-astro-zod-import.md
@@ -17,7 +17,13 @@ The [Astro documentation for `astro/zod`](https://docs.astro.build/en/reference/
 - Removes the need to install `zod` as a separate dependency.
 - Ensures your code uses the same Zod version as Astro's [Content Collections](https://docs.astro.build/en/guides/content-collections/) and [Actions](https://docs.astro.build/en/guides/actions/).
 
-This rule reports `import` and re-`export` declarations whose source is `zod` or any `zod/*` subpath, and offers an auto-fix when the replacement with `astro/zod` is API-compatible.
+This rule reports the following constructs whose source is `zod` or any `zod/*` subpath, and offers an auto-fix when the replacement with `astro/zod` is API-compatible:
+
+- `import` declarations and re-`export` declarations
+- Dynamic `import()` expressions (when the specifier is a static string)
+- TypeScript `import(...)` type queries (e.g. `typeof import("zod")`)
+
+Dynamic specifiers that cannot be resolved statically — identifiers, calls, or template literals containing expressions — are not reported.
 
 <ESLintCodeBlock fix>
 
@@ -29,10 +35,14 @@ This rule reports `import` and re-`export` declarations whose source is `zod` or
 
 /* ✓ GOOD */
 import { z } from "astro/zod"
+const zod = await import("astro/zod")
+type ZodModule = typeof import("astro/zod")
 
 /* ✗ BAD */
 import { z } from "zod"
 import { z } from "zod/v4"
+const zod = await import("zod")
+type ZodModule = typeof import("zod")
 ---
 ```
 

--- a/docs/rules/prefer-astro-zod-import.md
+++ b/docs/rules/prefer-astro-zod-import.md
@@ -1,0 +1,65 @@
+---
+title: "astro/prefer-astro-zod-import"
+description: "enforce importing Zod from `astro/zod` to stay in sync with the version bundled with Astro"
+---
+
+# astro/prefer-astro-zod-import
+
+> enforce importing Zod from `astro/zod` to stay in sync with the version bundled with Astro
+
+- 🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+- ❗ <badge text="This rule has not been released yet." vertical="middle" type="error"> **_This rule has not been released yet._** </badge>
+
+## 📖 Rule Details
+
+The [Astro documentation for `astro/zod`](https://docs.astro.build/en/reference/modules/astro-zod/#imports-from-astrozod) recommends importing Zod from `astro/zod` rather than from `zod` directly. Doing so:
+
+- Removes the need to install `zod` as a separate dependency.
+- Ensures your code uses the same Zod version as Astro's [Content Collections](https://docs.astro.build/en/guides/content-collections/) and [Actions](https://docs.astro.build/en/guides/actions/).
+
+This rule reports `import` and re-`export` declarations whose source is `zod` or any `zod/*` subpath, and offers an auto-fix when the replacement with `astro/zod` is API-compatible.
+
+<ESLintCodeBlock fix>
+
+<!--eslint-skip-->
+
+```astro
+---
+/* eslint astro/prefer-astro-zod-import: "error" */
+
+/* ✓ GOOD */
+import { z } from "astro/zod"
+
+/* ✗ BAD */
+import { z } from "zod"
+import { z } from "zod/v4"
+---
+```
+
+</ESLintCodeBlock>
+
+## 🔧 Options
+
+Nothing.
+
+## ⚠️ Notes on auto-fixing
+
+`astro/zod` re-exports Zod v4. The auto-fix is therefore only applied for sources that are API-compatible:
+
+- `zod` → `astro/zod` (fixed)
+- `zod/v4` → `astro/zod` (fixed)
+- `zod/v4-mini` → `astro/zod` (fixed)
+- `zod/v3`, `zod/locales/*`, etc. → reported only (no auto-fix), since the API differs from v4 or the subpath is not re-exported by `astro/zod`.
+
+## 📚 Further Reading
+
+- [Astro Documentation | The `astro/zod` module](https://docs.astro.build/en/reference/modules/astro-zod/)
+- [Astro Documentation | Imports from `astro/zod`](https://docs.astro.build/en/reference/modules/astro-zod/#imports-from-astrozod)
+
+
+
+## 🔍 Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-astro/blob/main/src/rules/prefer-astro-zod-import.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-astro/blob/main/tests/src/rules/prefer-astro-zod-import.ts)
+- [Test fixture sources](https://github.com/ota-meshi/eslint-plugin-astro/tree/main/tests/fixtures/rules/prefer-astro-zod-import)

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -226,6 +226,12 @@ module.exports = [
       },
     },
     {
+      files: ["tests/fixtures/rules/prefer-astro-zod-import/**/ts/*.astro"],
+      rules: {
+        "@typescript-eslint/consistent-type-imports": "off",
+      },
+    },
+    {
       files: ["**/*.md/*.js", "**/*.md/*.ts"],
       rules: {
         "@typescript-eslint/no-namespace": "off",

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -14,6 +14,7 @@ import noSetTextDirective from "./no-set-text-directive.ts"
 import noUnsafeInlineScripts from "./no-unsafe-inline-scripts.ts"
 import noUnusedCssSelector from "./no-unused-css-selector.ts"
 import noUnusedDefineVarsInStyle from "./no-unused-define-vars-in-style.ts"
+import preferAstroZodImport from "./prefer-astro-zod-import.ts"
 import preferClassListDirective from "./prefer-class-list-directive.ts"
 import preferObjectClassList from "./prefer-object-class-list.ts"
 import preferSplitClassList from "./prefer-split-class-list.ts"
@@ -37,6 +38,7 @@ export const originalRules: RuleModule[] = [
   noUnsafeInlineScripts,
   noUnusedCssSelector,
   noUnusedDefineVarsInStyle,
+  preferAstroZodImport,
   preferClassListDirective,
   preferObjectClassList,
   preferSplitClassList,

--- a/src/rules/prefer-astro-zod-import.ts
+++ b/src/rules/prefer-astro-zod-import.ts
@@ -1,0 +1,62 @@
+import type { TSESTree } from "@typescript-eslint/types"
+import { createRule } from "../utils/index.ts"
+import type { RuleModule } from "../types.ts"
+
+/** Source values whose direct replacement with `astro/zod` is API-compatible. */
+const FIXABLE_SOURCES = new Set(["zod", "zod/v4", "zod/v4-mini"])
+
+/** Returns `true` when the import source refers to the standalone Zod package. */
+function isZodSource(value: unknown): value is string {
+  return (
+    typeof value === "string" && (value === "zod" || value.startsWith("zod/"))
+  )
+}
+
+export default createRule("prefer-astro-zod-import", {
+  meta: {
+    docs: {
+      description:
+        "enforce importing Zod from `astro/zod` to stay in sync with the version bundled with Astro",
+      category: "Best Practices",
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      preferAstroZod:
+        "Prefer importing Zod from 'astro/zod' instead of '{{source}}' to stay in sync with the version bundled with Astro.",
+    },
+    type: "suggestion",
+    fixable: "code",
+  },
+  create(context) {
+    /** Reports the given import/export source if it targets `zod`. */
+    function checkSource(
+      sourceNode: TSESTree.StringLiteral | null | undefined,
+    ) {
+      if (!sourceNode || !isZodSource(sourceNode.value)) {
+        return
+      }
+      const source = sourceNode.value
+      context.report({
+        node: sourceNode,
+        messageId: "preferAstroZod",
+        data: { source },
+        fix: FIXABLE_SOURCES.has(source)
+          ? (fixer) => fixer.replaceText(sourceNode, `"astro/zod"`)
+          : null,
+      })
+    }
+
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        checkSource(node.source)
+      },
+      ExportNamedDeclaration(node: TSESTree.ExportNamedDeclaration) {
+        checkSource(node.source)
+      },
+      ExportAllDeclaration(node: TSESTree.ExportAllDeclaration) {
+        checkSource(node.source)
+      },
+    }
+  },
+}) satisfies RuleModule

--- a/src/rules/prefer-astro-zod-import.ts
+++ b/src/rules/prefer-astro-zod-import.ts
@@ -12,7 +12,43 @@ function isZodSource(value: unknown): value is string {
   )
 }
 
-export default createRule("prefer-astro-zod-import", {
+/**
+ * Returns the given node when it is a string-valued `Literal`, otherwise `null`.
+ * Dynamic sources we cannot statically resolve (template literals with
+ * expressions, identifiers, calls, etc.) are intentionally skipped.
+ */
+function asStringLiteral(
+  node: TSESTree.Node | null | undefined,
+): TSESTree.StringLiteral | null {
+  if (node && node.type === "Literal" && typeof node.value === "string") {
+    return node
+  }
+  return null
+}
+
+/**
+ * Resolves the string-literal source of a `TSImportType` across both
+ * `@typescript-eslint/types` v7 (only `argument` is populated) and v8+
+ * (the dedicated `source` field).
+ */
+function getTSImportTypeSource(
+  node: TSESTree.TSImportType,
+): TSESTree.StringLiteral | null {
+  const v8Source = (
+    node as TSESTree.TSImportType & { source?: TSESTree.StringLiteral }
+  ).source
+  if (v8Source) {
+    return asStringLiteral(v8Source)
+  }
+  const arg = (node as TSESTree.TSImportType & { argument?: TSESTree.Node })
+    .argument
+  if (arg && arg.type === "TSLiteralType") {
+    return asStringLiteral(arg.literal)
+  }
+  return null
+}
+
+const rule: RuleModule = createRule("prefer-astro-zod-import", {
   meta: {
     docs: {
       description:
@@ -29,7 +65,7 @@ export default createRule("prefer-astro-zod-import", {
     fixable: "code",
   },
   create(context) {
-    /** Reports the given import/export source if it targets `zod`. */
+    /** Reports the given source string literal if it targets `zod`. */
     function checkSource(
       sourceNode: TSESTree.StringLiteral | null | undefined,
     ) {
@@ -57,6 +93,14 @@ export default createRule("prefer-astro-zod-import", {
       ExportAllDeclaration(node: TSESTree.ExportAllDeclaration) {
         checkSource(node.source)
       },
+      ImportExpression(node: TSESTree.ImportExpression) {
+        checkSource(asStringLiteral(node.source))
+      },
+      TSImportType(node: TSESTree.TSImportType) {
+        checkSource(getTSImportTypeSource(node))
+      },
     }
   },
-}) satisfies RuleModule
+})
+
+export default rule

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/bare-zod-errors.json
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/bare-zod-errors.json
@@ -1,0 +1,7 @@
+[
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod' to stay in sync with the version bundled with Astro.",
+    "line": 2,
+    "column": 19
+  }
+]

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/bare-zod-input.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/bare-zod-input.astro
@@ -1,0 +1,4 @@
+---
+import { z } from "zod"
+const schema = z.string()
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/bare-zod-output.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/bare-zod-output.astro
@@ -1,0 +1,4 @@
+---
+import { z } from "astro/zod"
+const schema = z.string()
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/re-exports-errors.json
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/re-exports-errors.json
@@ -1,0 +1,12 @@
+[
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod' to stay in sync with the version bundled with Astro.",
+    "line": 2,
+    "column": 19
+  },
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod/v4' to stay in sync with the version bundled with Astro.",
+    "line": 3,
+    "column": 15
+  }
+]

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/re-exports-input.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/re-exports-input.astro
@@ -1,0 +1,4 @@
+---
+export { z } from "zod"
+export * from "zod/v4"
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/re-exports-output.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/re-exports-output.astro
@@ -1,0 +1,4 @@
+---
+export { z } from "astro/zod"
+export * from "astro/zod"
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/_config.json
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/_config.json
@@ -1,0 +1,7 @@
+{
+  "languageOptions": {
+    "parserOptions": {
+      "parser": "@typescript-eslint/parser"
+    }
+  }
+}

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/dynamic-import-errors.json
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/dynamic-import-errors.json
@@ -1,0 +1,17 @@
+[
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod' to stay in sync with the version bundled with Astro.",
+    "line": 2,
+    "column": 26
+  },
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod/v4' to stay in sync with the version bundled with Astro.",
+    "line": 3,
+    "column": 28
+  },
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod/v4-mini' to stay in sync with the version bundled with Astro.",
+    "line": 4,
+    "column": 32
+  }
+]

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/dynamic-import-input.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/dynamic-import-input.astro
@@ -1,0 +1,5 @@
+---
+const zod = await import("zod")
+const zodV4 = await import("zod/v4")
+const zodV4Mini = await import("zod/v4-mini")
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/dynamic-import-output.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/dynamic-import-output.astro
@@ -1,0 +1,5 @@
+---
+const zod = await import("astro/zod")
+const zodV4 = await import("astro/zod")
+const zodV4Mini = await import("astro/zod")
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/non-fixable-dynamic-and-type-errors.json
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/non-fixable-dynamic-and-type-errors.json
@@ -1,0 +1,12 @@
+[
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod/v3' to stay in sync with the version bundled with Astro.",
+    "line": 4,
+    "column": 25
+  },
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod/locales/de' to stay in sync with the version bundled with Astro.",
+    "line": 5,
+    "column": 35
+  }
+]

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/non-fixable-dynamic-and-type-input.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/non-fixable-dynamic-and-type-input.astro
@@ -1,0 +1,6 @@
+---
+// `zod/v3` and `zod/locales/*` are reported but not auto-fixed because the
+// API of `astro/zod` (Zod v4) is not compatible / does not re-export them.
+const v3 = await import("zod/v3")
+type LocaleModule = typeof import("zod/locales/de")
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/non-fixable-dynamic-and-type-output.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/non-fixable-dynamic-and-type-output.astro
@@ -1,0 +1,6 @@
+---
+// `zod/v3` and `zod/locales/*` are reported but not auto-fixed because the
+// API of `astro/zod` (Zod v4) is not compatible / does not re-export them.
+const v3 = await import("zod/v3")
+type LocaleModule = typeof import("zod/locales/de")
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/review-example-errors.json
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/review-example-errors.json
@@ -1,0 +1,12 @@
+[
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod' to stay in sync with the version bundled with Astro.",
+    "line": 3,
+    "column": 24
+  },
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod' to stay in sync with the version bundled with Astro.",
+    "line": 3,
+    "column": 46
+  }
+]

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/review-example-input.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/review-example-input.astro
@@ -1,0 +1,4 @@
+---
+// Original example from the maintainer review on PR #567.
+const z: typeof import("zod") = await import("zod")
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/review-example-output.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/review-example-output.astro
@@ -1,0 +1,4 @@
+---
+// Original example from the maintainer review on PR #567.
+const z: typeof import("astro/zod") = await import("astro/zod")
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/ts-import-type-errors.json
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/ts-import-type-errors.json
@@ -1,0 +1,17 @@
+[
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod' to stay in sync with the version bundled with Astro.",
+    "line": 2,
+    "column": 32
+  },
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod' to stay in sync with the version bundled with Astro.",
+    "line": 3,
+    "column": 25
+  },
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod/v4-mini' to stay in sync with the version bundled with Astro.",
+    "line": 4,
+    "column": 25
+  }
+]

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/ts-import-type-input.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/ts-import-type-input.astro
@@ -1,0 +1,5 @@
+---
+type ZodModule = typeof import("zod")
+type ZodSchema = import("zod").ZodTypeAny
+let mini: typeof import("zod/v4-mini") = null as never
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/ts-import-type-output.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/ts/ts-import-type-output.astro
@@ -1,0 +1,5 @@
+---
+type ZodModule = typeof import("astro/zod")
+type ZodSchema = import("astro/zod").ZodTypeAny
+let mini: typeof import("astro/zod") = null as never
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/zod-non-fixable-errors.json
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/zod-non-fixable-errors.json
@@ -1,0 +1,12 @@
+[
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod/v3' to stay in sync with the version bundled with Astro.",
+    "line": 3,
+    "column": 19
+  },
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod/locales/de' to stay in sync with the version bundled with Astro.",
+    "line": 4,
+    "column": 16
+  }
+]

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/zod-non-fixable-input.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/zod-non-fixable-input.astro
@@ -1,0 +1,5 @@
+---
+// `zod/v3` is NOT API-compatible with astro/zod (which is v4); should be reported but NOT auto-fixed.
+import { z } from "zod/v3"
+import de from "zod/locales/de"
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/zod-non-fixable-output.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/zod-non-fixable-output.astro
@@ -1,0 +1,5 @@
+---
+// `zod/v3` is NOT API-compatible with astro/zod (which is v4); should be reported but NOT auto-fixed.
+import { z } from "zod/v3"
+import de from "zod/locales/de"
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/zod-v4-errors.json
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/zod-v4-errors.json
@@ -1,0 +1,12 @@
+[
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod/v4' to stay in sync with the version bundled with Astro.",
+    "line": 2,
+    "column": 19
+  },
+  {
+    "message": "Prefer importing Zod from 'astro/zod' instead of 'zod/v4-mini' to stay in sync with the version bundled with Astro.",
+    "line": 3,
+    "column": 28
+  }
+]

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/zod-v4-input.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/zod-v4-input.astro
@@ -1,0 +1,4 @@
+---
+import { z } from "zod/v4"
+import { z as zMini } from "zod/v4-mini"
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/invalid/zod-v4-output.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/invalid/zod-v4-output.astro
@@ -1,0 +1,4 @@
+---
+import { z } from "astro/zod"
+import { z as zMini } from "astro/zod"
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/valid/test01-input.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/valid/test01-input.astro
@@ -1,0 +1,6 @@
+---
+import { z } from "astro/zod"
+export {} from "astro/zod"
+
+const schema = z.string()
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/valid/test02-input.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/valid/test02-input.astro
@@ -1,0 +1,6 @@
+---
+// astro/zod re-exports zod v4 — anything not under "zod"/"zod/*" should NOT be flagged.
+import myThing from "zoderoo"
+import other from "@org/zod"
+import another from "not-zod/v4"
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/valid/ts/_config.json
+++ b/tests/fixtures/rules/prefer-astro-zod-import/valid/ts/_config.json
@@ -1,0 +1,7 @@
+{
+  "languageOptions": {
+    "parserOptions": {
+      "parser": "@typescript-eslint/parser"
+    }
+  }
+}

--- a/tests/fixtures/rules/prefer-astro-zod-import/valid/ts/astro-zod-everywhere-input.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/valid/ts/astro-zod-everywhere-input.astro
@@ -1,0 +1,10 @@
+---
+// `astro/zod` used in every form the rule now recognises: declaration import,
+// dynamic `import()` expression and TypeScript `import(...)` type query.
+import { z } from "astro/zod"
+
+type ZodModule = typeof import("astro/zod")
+const m: ZodModule = await import("astro/zod")
+
+const schema = z.string()
+---

--- a/tests/fixtures/rules/prefer-astro-zod-import/valid/ts/non-static-dynamic-import-input.astro
+++ b/tests/fixtures/rules/prefer-astro-zod-import/valid/ts/non-static-dynamic-import-input.astro
@@ -1,0 +1,7 @@
+---
+// Dynamic sources that cannot be statically resolved to a string literal
+// must not be reported. The rule has no way to know what these resolve to.
+const pkg = "zod"
+const dyn = await import(pkg)
+const tpl = await import(`zod-${"plugin"}`)
+---

--- a/tests/src/rules/prefer-astro-zod-import.ts
+++ b/tests/src/rules/prefer-astro-zod-import.ts
@@ -1,0 +1,16 @@
+import { RuleTester } from "../../utils/eslint-compat.ts"
+import rule from "../../../src/rules/prefer-astro-zod-import.ts"
+import { loadTestCases } from "../../utils/utils.ts"
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
+})
+
+tester.run(
+  "prefer-astro-zod-import",
+  rule as never,
+  loadTestCases("prefer-astro-zod-import"),
+)


### PR DESCRIPTION
Closes #558

## Summary

Adds a new rule, `astro/prefer-astro-zod-import`, that enforces importing Zod from `astro/zod` rather than from the standalone `zod` package or any of its subpaths. This keeps consumer code in sync with the version of Zod bundled with Astro and matches the recommendation in [the Astro docs](https://docs.astro.build/en/reference/modules/astro-zod/#imports-from-astrozod).

## Behavior

- Reports `import` and re-`export` declarations whose source is `zod` or `zod/*`.
- Auto-fixes API-compatible sources to `astro/zod`:
  - `zod` → `astro/zod`
  - `zod/v4` → `astro/zod`
  - `zod/v4-mini` → `astro/zod`
- Reports without auto-fix for sources that aren't safe to rewrite, since `astro/zod` only re-exports Zod v4:
  - `zod/v3` (different API)
  - `zod/locales/*` (not re-exported)

## Defaults

- `recommended: false`, `category: "Best Practices"`, `fixable: "code"`, `type: "suggestion"`.
- Left out of the recommended config so projects that intentionally pin a specific `zod` version aren't impacted.

## Tests

`npm run test -- -g prefer-astro-zod-import` — 7 passing, covering:

- valid: importing from `astro/zod`, importing unrelated packages
- invalid (auto-fixed): bare `zod`, `zod/v4`, re-exports (`export { z } from "zod"`, `export * from "zod"`)
- invalid (report-only): `zod/v3`, `zod/locales/de`

Full suite (`npm run test`): 316 passing.

## Notes

- Added a changeset (`minor`) per `CONTRIBUTING.md`.
- Documentation page added at `docs/rules/prefer-astro-zod-import.md`, following the structure of existing rule docs; intentionally omitted `since` per the contributing guide.
- README and rule index were updated by hand (matching the existing alphabetical ordering) rather than via `npm run update`, to keep this PR scoped strictly to the new rule.
