### PR TITLE
fix: support component className selectors

### DIFF
--- a/.changeset/quiet-cards-smile.md
+++ b/.changeset/quiet-cards-smile.md
@@ -1,0 +1,6 @@
+---
+"eslint-plugin-astro": patch
+---
+
+Fix false positives in `no-unused-css-selector` for classes passed to components
+through `className`.

--- a/src/rules/no-unused-css-selector.ts
+++ b/src/rules/no-unused-css-selector.ts
@@ -477,10 +477,29 @@ function nodeToJSXElementMatcher(
   })()
   return (element, subject) => {
     if (isComponentElement(element)) {
+      if (selector.type === "class") {
+        return componentClassNameMatches(selector, element, context)
+      }
       return false
     }
     return baseMatcher(element, subject)
   }
+}
+
+/** Check whether a component's className prop can match the selector. */
+function componentClassNameMatches(
+  selector: parser.ClassName,
+  element: JSXElementTreeNode,
+  context: RuleContext,
+): boolean {
+  const attr = getAttribute(element, "className", context)
+  if (attr == null) {
+    return false
+  }
+  if (attr.unknown || !attr.staticValue) {
+    return true
+  }
+  return attr.staticValue.value.split(/\s+/u).includes(selector.value)
 }
 
 /**

--- a/tests/fixtures/rules/no-unused-css-selector/valid/component-class-name01-input.astro
+++ b/tests/fixtures/rules/no-unused-css-selector/valid/component-class-name01-input.astro
@@ -1,0 +1,26 @@
+---
+import Card from "@/components/Card.astro"
+import Section from "@/components/Section.astro"
+---
+
+<Section>
+  <Card className="special-card">
+    <p>Hello World!</p>
+  </Card>
+</Section>
+
+<Section>
+  <Card className={"another-special-card"}>
+    <p>Lorem Ipsum</p>
+  </Card>
+</Section>
+
+<style>
+  .special-card {
+    background-color: red;
+  }
+
+  .another-special-card {
+    background-color: blue;
+  }
+</style>


### PR DESCRIPTION
Closes #602

Teach `no-unused-css-selector` to match class selectors against a component's `className` prop. Static values are matched by class token, while dynamic values are treated conservatively to avoid false positives. Other selector types and the existing handling of `class` on components remain unchanged.

A valid fixture covers both literal and expression-valued `className` props, and a patch changeset documents the user-visible fix.

## Verification

- Focused `no-unused-css-selector` suite: 68 passing
- Full unit suite: 312 passing
- `npm run lint`
- `npm run test:type`

AI disclosure: Codex assisted with issue research, implementation, and validation. I reviewed the rule semantics, existing component fixtures, final diff, and test results before submission.