### PR TITLE
chore: fix integration tests path separator on Windows

### DIFF
--- a/tests/integration/test.ts
+++ b/tests/integration/test.ts
@@ -52,7 +52,7 @@ for (const dirent of fs.readdirSync(TEST_FIXTURES_ROOT, {
           assert.ok(Array.isArray(results), "output is not array")
           const result = results.map((r) => ({
             ...r,
-            filePath: path.relative(TEST_CWD, r.filePath),
+            filePath: path.relative(TEST_CWD, r.filePath).replace(/\\/g, "/"),
           }))
           fs.writeFileSync(actualFile, JSON.stringify(result, null, 2))
 


### PR DESCRIPTION
### Description
This PR fixes a small issue that causes the `test:integration` script to fail on Windows environments.

**The Bug:**
When running integration tests on Windows, ESLint outputs file paths using backslashes (e.g., `src\index.astro`), which causes a strict deep-equal assertion failure against `expected.json` (which expects forward slashes like `src/index.astro`).

**The Fix:**
Updated `tests/integration/test.ts` to normalize the generated `filePath` by replacing backslashes with forward slashes before asserting. This ensures the integration tests pass reliably across all operating systems.