### PR TITLE
fix(no-unused-css-selector): lint SCSS when imports fail

### DIFF
--- a/.changeset/curly-cats-lint.md
+++ b/.changeset/curly-cats-lint.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-astro": patch
+---
+
+fix: keep checking SCSS selectors when Sass imports cannot be resolved

--- a/src/utils/transform/index.ts
+++ b/src/utils/transform/index.ts
@@ -46,6 +46,13 @@ export function getStyleContentCSS(
     transform = transformWithStylus(node, context)
   }
   if (!transform) {
+    if (lang === "scss") {
+      const inputRange = getContentRange(node)
+      return {
+        css: sourceCode.text.slice(...inputRange),
+        remap: (i) => inputRange[0] + i,
+      }
+    }
     return null
   }
 

--- a/tests/fixtures/rules/no-unused-css-selector/invalid/scss-unresolved-import-errors.json
+++ b/tests/fixtures/rules/no-unused-css-selector/invalid/scss-unresolved-import-errors.json
@@ -1,0 +1,7 @@
+[
+  {
+    "message": "Unused CSS selector `.ok`",
+    "line": 12,
+    "column": 3
+  }
+]

--- a/tests/fixtures/rules/no-unused-css-selector/invalid/scss-unresolved-import-input.astro
+++ b/tests/fixtures/rules/no-unused-css-selector/invalid/scss-unresolved-import-input.astro
@@ -1,0 +1,19 @@
+---
+const { name } = Astro.props
+---
+
+<div class="hello">
+  <p>Hello, {name}!</p>
+</div>
+
+<style lang="scss">
+  @use "../styles/mixins" as mixins;
+
+  .ok {
+    color: red;
+
+    @include mixins.breakpoint("small") {
+      display: none;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary

- Fall back to parsing raw SCSS when Sass compilation fails because an import cannot be resolved.
- Preserve the existing Sass, CSS, Less, and Stylus transform behavior.
- Add a regression fixture for an unresolved `@use` that still reports an unused selector.

Fixes #399.

## Validation

- `npm run test -- --grep no-unused-css-selector` (`68` passing)
- `npm test` (`314` passing)
- `npm run lint:ts`
- `npm run lint:js`
- `git diff --check`

Assisted-by: OpenAI Codex. The contributor reviewed the implementation and validation before publication.
