### PR TITLE
Resolve the TypeScript parser from the `typescript-eslint` package when `@typescript-eslint/parser` is not installed directly

### DIFF
--- a/.changeset/calm-parsers-smile.md
+++ b/.changeset/calm-parsers-smile.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-astro": minor
+---
+
+Resolve the TypeScript parser from the `typescript-eslint` package when `@typescript-eslint/parser` is not installed directly.

--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ See [documents](https://ota-meshi.github.io/eslint-plugin-astro/).
 npm install --save-dev eslint eslint-plugin-astro
 ```
 
-If you write TypeScript in Astro components, you also need to install the `@typescript-eslint/parser`:
+If you write TypeScript in Astro components, you also need to install either `typescript-eslint` or `@typescript-eslint/parser`:
 
 ```bash
+npm install --save-dev typescript-eslint
+# or
 npm install --save-dev @typescript-eslint/parser
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -8,9 +8,11 @@
 npm install --save-dev eslint eslint-plugin-astro
 ```
 
-If you write TypeScript in Astro components, you also need to install the `@typescript-eslint/parser`:
+If you write TypeScript in Astro components, you also need to install either `typescript-eslint` or `@typescript-eslint/parser`:
 
 ```bash
+npm install --save-dev typescript-eslint
+# or
 npm install --save-dev @typescript-eslint/parser
 ```
 

--- a/package.json
+++ b/package.json
@@ -81,13 +81,17 @@
   "peerDependencies": {
     "@typescript-eslint/parser": ">=8.61.0",
     "eslint": ">=10.0.0",
-    "eslint-plugin-jsx-a11y": ">=6.10.2"
+    "eslint-plugin-jsx-a11y": ">=6.10.2",
+    "typescript-eslint": ">=8.61.0"
   },
   "peerDependenciesMeta": {
     "@typescript-eslint/parser": {
       "optional": true
     },
     "eslint-plugin-jsx-a11y": {
+      "optional": true
+    },
+    "typescript-eslint": {
       "optional": true
     }
   },

--- a/src/configs/has-typescript-eslint-parser.ts
+++ b/src/configs/has-typescript-eslint-parser.ts
@@ -1,15 +1,25 @@
-import { createRequire } from "node:module"
-import path from "node:path"
-import type tsParser from "@typescript-eslint/parser"
+import type { Linter } from "eslint"
+import { requireUserLocal } from "../utils/resolve-parser/require-user.ts"
 
-export let hasTypescriptEslintParser = false
-export let tsESLintParser: typeof tsParser | null = null
-
-try {
-  const cwd = process.cwd()
-  const relativeTo = path.join(cwd, "__placeholder__.js")
-  if ((tsESLintParser = createRequire(relativeTo)("@typescript-eslint/parser")))
-    hasTypescriptEslintParser = true
-} catch {
-  // noop
+type TypescriptEslint = {
+  parser?: Linter.Parser
+  default?: {
+    parser?: Linter.Parser
+  }
 }
+
+/** Load the TypeScript parser installed in the user's project. */
+function loadTypescriptEslintParser(): Linter.Parser | null {
+  const parser = requireUserLocal<Linter.Parser>("@typescript-eslint/parser")
+  if (parser) {
+    return parser
+  }
+
+  const typescriptEslint =
+    requireUserLocal<TypescriptEslint>("typescript-eslint")
+  return typescriptEslint?.parser ?? typescriptEslint?.default?.parser ?? null
+}
+
+export const tsESLintParser: Linter.Parser | null = loadTypescriptEslintParser()
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- Avoid isolatedDeclarations error
+export const hasTypescriptEslintParser = Boolean(tsESLintParser) as boolean

--- a/tests/src/integration/typescript-eslint-fallback.ts
+++ b/tests/src/integration/typescript-eslint-fallback.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert"
+import childProcess from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+describe("Integration test for typescript-eslint parser fallback", () => {
+  it("should use the parser exported by typescript-eslint", () => {
+    const cwd = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eslint-plugin-astro-typescript-eslint-"),
+    )
+
+    try {
+      const typescriptEslintDirectory = path.join(
+        cwd,
+        "node_modules/typescript-eslint",
+      )
+      fs.mkdirSync(typescriptEslintDirectory, { recursive: true })
+      fs.writeFileSync(
+        path.join(typescriptEslintDirectory, "package.json"),
+        JSON.stringify({ main: "index.cjs" }),
+      )
+      fs.writeFileSync(
+        path.join(typescriptEslintDirectory, "index.cjs"),
+        `module.exports = require(${JSON.stringify(
+          fileURLToPath(import.meta.resolve("typescript-eslint")),
+        )})\n`,
+      )
+
+      const childSource = `
+import assert from "node:assert"
+import path from "node:path"
+import { createRequire } from "node:module"
+import { ESLint } from ${JSON.stringify(import.meta.resolve("eslint"))}
+
+assert.strictEqual(process.env.NODE_PATH, undefined)
+const requireFromCwd = createRequire(
+  path.join(process.cwd(), "__placeholder__.js"),
+)
+assert.throws(
+  () => requireFromCwd.resolve("@typescript-eslint/parser"),
+  { code: "MODULE_NOT_FOUND" },
+)
+assert.doesNotThrow(() => requireFromCwd.resolve("typescript-eslint"))
+
+const { default: astroPlugin } = await import(${JSON.stringify(
+        new URL("../../../src/index.mts", import.meta.url).href,
+      )})
+const eslint = new ESLint({
+  overrideConfigFile: true,
+  overrideConfig: [...astroPlugin.configs.base],
+})
+const [result] = await eslint.lintText(
+  ${JSON.stringify(`---
+import type { Foo } from "./types"
+const foo: Foo = {} as Foo
+---
+<div>{foo}</div>
+<script>
+const clientValue: string = "value"
+console.log(clientValue)
+</script>
+`)},
+  { filePath: "src/index.astro" },
+)
+assert.deepStrictEqual(result.messages, [])
+`
+      // eslint-disable-next-line no-process-env -- The child must not inherit NODE_PATH.
+      const inheritedEnvironment = process.env
+      const env = Object.fromEntries(
+        Object.entries(inheritedEnvironment).filter(
+          ([key]) => key.toUpperCase() !== "NODE_PATH",
+        ),
+      )
+      const child = childProcess.spawnSync(
+        process.execPath,
+        [
+          "--no-global-search-paths",
+          "--import",
+          import.meta.resolve("@oxc-node/core/register"),
+          "--input-type=module",
+        ],
+        {
+          cwd,
+          encoding: "utf8",
+          env,
+          input: childSource,
+          timeout: 60_000,
+        },
+      )
+
+      assert.ifError(child.error)
+      assert.strictEqual(child.status, 0, child.stderr || child.stdout)
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
close #608