### PR TITLE
Fix Changesets action v2 inputs

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -43,8 +43,8 @@ jobs:
         uses: changesets/action@v2.0.0
         with:
           # this expects you to have a npm script called version that runs some logic and then calls `changeset version`.
-          version: npm run version:ci
+          version-script: npm run version:ci
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: npm run release
+          publish-script: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changesets Action v2 renamed the `version` and `publish` inputs. The release workflow still passes the v1 names, so the action exits before running either script.

Use `version-script` and `publish-script` while preserving the existing commands. This restores release pull request creation and publishing on pushes to `main`.
