### PR TITLE
ci: work around npm 10 "edgesOut" crash on Node 22 test job

### DIFF
--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -52,6 +52,11 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Update npm
+        # npm 10 (bundled with Node 22) crashes with
+        # "Cannot read properties of null (reading 'edgesOut')"
+        # while resolving the peer set of vitest@4.1.11.
+        run: npm install -g npm@^11
       - name: Install Packages
         run: npm install -f
       - name: Test


### PR DESCRIPTION
## Problem

Since 2026-08-18, the `test (22.22.3)` CI job fails on every PR (e.g. #626) during `npm install -f`:

```
npm error Cannot read properties of null (reading 'edgesOut')
```

The other matrix jobs (`24.16.0`, `26.3.0`) are then canceled by fail-fast. Jobs using `lts/*` (npm 11) pass.

## Cause

This is an arborist bug in npm 10.9.8 (bundled with Node 22), crashing in `#loadPeerSet` while building the ideal tree. It is triggered by the peer dependency graph of `vitest@4.1.11` (published 2026-08-18 14:27 UTC — matching the first failure at 16:41 UTC), which npm resolves transitively via `vite` → `@vitejs/devtools` (optional peer) → `@vitejs/devtools-vitest` → `vitest@*`, even though vitest is never actually installed.

Reproduced locally: a clean `npm install -f` with npm 10.9.8 crashes; the same install with npm 11 succeeds.

## Fix

Upgrade npm to v11 (supports Node `^20.17.0 || >=22.9.0`) in the test job before installing. This is a no-op on Node 24/26, which already bundle npm 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)